### PR TITLE
Show manager while waiting for MM enable

### DIFF
--- a/assets/newsroom-management/App.tsx
+++ b/assets/newsroom-management/App.tsx
@@ -7,7 +7,7 @@ import { ManagerState } from "../shared/reducer";
 import { addAddress, addTxHash, setMetaMaskEnabled } from "../shared/actions";
 import { saveAddressToProfile } from "../api-helpers";
 import { apiNamespace, siteOptionKeys, userMetaKeys, NETWORK_NAME, NETWORK_NICE_NAME, theme, urls } from "../constants";
-import { getCivil, getIPFS } from "../util";
+import { getCivil, getIPFS, getMetaMaskEnabled } from "../util";
 import { Modal, buttonSizes, Button } from "@joincivil/components";
 import { SearchUsers } from "./SearchUsers";
 
@@ -60,6 +60,9 @@ class App extends React.Component<AppProps & DispatchProp<any>, AppState> {
     } catch (err) {
       console.error("Failed to fetch user info for profile wallet address:", err);
     }
+
+    const metaMaskEnabled = await getMetaMaskEnabled();
+    this.props.dispatch(setMetaMaskEnabled(metaMaskEnabled));
   }
 
   public async componentWillUnmount(): Promise<void> {

--- a/assets/newsroom-management/index.tsx
+++ b/assets/newsroom-management/index.tsx
@@ -5,9 +5,7 @@ import thunk from "redux-thunk";
 import { Provider } from "react-redux";
 import { Map } from "immutable";
 import { ErrorBoundary } from "../shared/components/ErrorBoundary";
-import { setMetaMaskEnabled } from "../shared/actions";
 import reducers from "../shared/reducer";
-import { getMetaMaskEnabled } from "../util";
 import App from "./App";
 
 async function init(): Promise<void> {
@@ -19,8 +17,6 @@ async function init(): Promise<void> {
     },
     applyMiddleware(thunk),
   );
-  const metaMaskEnabled = await getMetaMaskEnabled();
-  store.dispatch(setMetaMaskEnabled(metaMaskEnabled));
 
   ReactDOM.render(
     <ErrorBoundary section="newsroom-manager">

--- a/assets/post-panel/components/CivilNavBarButtons.tsx
+++ b/assets/post-panel/components/CivilNavBarButtons.tsx
@@ -29,6 +29,7 @@ const IconSection = styled.span`
   align-items: center;
   background-color: "transparent";
   border-radius: 0 4px 4px 0;
+  cursor: pointer;
 `;
 
 const PanelButtonSign = styled<{ open: boolean }, "span">("span")`

--- a/assets/post-panel/components/RevisionLinks.tsx
+++ b/assets/post-panel/components/RevisionLinks.tsx
@@ -35,14 +35,12 @@ export const RevisionLinks = (props: RevisionLinksProps): JSX.Element => {
   let archiveSection;
 
   if (props.lastArchivedRevision) {
-    const transactionArchive = (
-      <Link
-        href={`https://${urls.ETHERSCAN_DOMAIN}/tx/${props.lastArchivedRevision.txHash}`}
-        disabled={!props.lastArchivedRevision.archive.transaction}
-        target="_blank"
-      >
-        {props.lastArchivedRevision.archive.transaction ? "View on Ethereum" : "Not Archived to Ethereum"}{" "}
+    const transactionArchive = props.lastArchivedRevision.archive.transaction ? (
+      <Link href={`https://${urls.ETHERSCAN_DOMAIN}/tx/${props.lastArchivedRevision.txHash}`} target="_blank">
+        View on Ethereum
       </Link>
+    ) : (
+      <Link disabled>Not Archived to Ethereum</Link>
     );
 
     archiveSection = (

--- a/assets/post-panel/index.tsx
+++ b/assets/post-panel/index.tsx
@@ -7,7 +7,17 @@ const { compose } = window.wp.compose;
 import * as React from "react";
 import { Civil, EthAddress } from "@joincivil/core";
 import { colors, IconWrap, Wrapper, Body, BodySection } from "./styles";
-import { Tabs, Tab, TabComponentProps, Button, buttonSizes, CivilLogo, NorthEastArrow, ArticleIndexIcon, ArticleSignIcon } from "@joincivil/components";
+import {
+  Tabs,
+  Tab,
+  TabComponentProps,
+  Button,
+  buttonSizes,
+  CivilLogo,
+  NorthEastArrow,
+  ArticleIndexIcon,
+  ArticleSignIcon,
+} from "@joincivil/components";
 import { theme, urls } from "../constants";
 import { getCivil } from "../util";
 import { ErrorBoundary } from "../shared/components/ErrorBoundary";
@@ -126,10 +136,24 @@ class BlockchainPluginInnerComponent extends React.Component<BlockchainPluginPro
         TabsNavBefore={navLogo}
         TabsNavAfter={navHelp}
       >
-        <Tab title={<TabLabel><ArticleSignIcon size={17}/><TabLabelText>Sign</TabLabelText></TabLabel>}>
+        <Tab
+          title={
+            <TabLabel>
+              <ArticleSignIcon size={17} />
+              <TabLabelText>Sign</TabLabelText>
+            </TabLabel>
+          }
+        >
           <BlockchainSignPanel />
         </Tab>
-        <Tab title={<TabLabel><ArticleIndexIcon size={17}/><TabLabelText>Publish</TabLabelText></TabLabel>}>
+        <Tab
+          title={
+            <TabLabel>
+              <ArticleIndexIcon size={17} />
+              <TabLabelText>Publish</TabLabelText>
+            </TabLabel>
+          }
+        >
           <BlockchainPublishPanel />
         </Tab>
       </Tabs>


### PR DESCRIPTION
I got stuck in some state where MM modals never popped up (just badge on icon) so the blank page before enable was pretty confusing.

Any reason not to trigger MM enable inside component like this, so that component can render in disabled state (showing "please enable" in WalletOnboarding component) instead of triggering before rendering component? Tested and works ok.

PR also has a couple other tiny bits I had on my machine.