### PR TITLE
Allow control of story boost widget output priority [CIVIL-1387]

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -58,7 +58,7 @@ function add_menus() {
 			TOP_LEVEL_MENU,
 			__( 'Credibility Indicators', 'civil' ),
 			__( 'Credibility Indicators', 'civil' ),
-			'manage_options',
+			'edit_posts',
 			CREDIBILITY_INDICATORS,
 			__NAMESPACE__ . '\credibililty_indicators_content'
 		);
@@ -116,9 +116,6 @@ function help_menu_content() {
  * Credibiity Indicators content.
  */
 function credibililty_indicators_content() {
-	if ( ! current_user_can( 'manage_options' ) ) {
-		wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'civil' ) );
-	}
 	require_once dirname( __FILE__ ) . '/credibililty-indicators.php';
 }
 

--- a/admin.php
+++ b/admin.php
@@ -53,6 +53,15 @@ function add_menus() {
 		);
 	}
 
+	add_submenu_page(
+		TOP_LEVEL_MENU,
+		__( 'Story Boosts', 'civil' ),
+		__( 'Story Boosts', 'civil' ),
+		'edit_posts',
+		STORY_BOOSTS_SETTINGS,
+		__NAMESPACE__ . '\story_boosts_settings_content'
+	);
+
 	if ( apply_filters( 'civil_enable_credibility_indicators', true ) ) {
 		add_submenu_page(
 			TOP_LEVEL_MENU,
@@ -110,6 +119,13 @@ function help_menu_content() {
 		wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'civil' ) );
 	}
 	require_once dirname( __FILE__ ) . '/faq-help.php';
+}
+
+/**
+ * Story Boosts Settings content.
+ */
+function story_boosts_settings_content() {
+	require_once dirname( __FILE__ ) . '/story-boosts-settings.php';
 }
 
 /**

--- a/civil-publisher.php
+++ b/civil-publisher.php
@@ -3,7 +3,7 @@
  * Plugin Name: Civil Publisher
  * Plugin URI: https://github.com/joincivil/civil-publisher-wordpress-plugin
  * Description: Use Civil's growing suite of publisher tools, including: Boosts, to let readers easily support to your newsroom from any article; Credibility Indicators, to educate readers about what work goes into good journalism, and our smart contract tools (experimental) to publish and archive content on the Ethereum blockchain.
- * Version: 0.7.0
+ * Version: 0.7.1
  * Author: Civil
  * Author URI: https://civil.co
  *
@@ -38,6 +38,8 @@ define( __NAMESPACE__ . '\NEWSROOM_ADDRESS_OPTION_KEY', 'civil_publisher_newsroo
 define( __NAMESPACE__ . '\NEWSROOM_TXHASH_OPTION_KEY', 'civil_publisher_newsroom_txhash' );
 define( __NAMESPACE__ . '\NEWSROOM_CHARTER_OPTION_KEY', 'civil_publisher_newsroom_charter' );
 define( __NAMESPACE__ . '\NETWORK_NAME_OPTION_KEY', 'civil_publisher_network_name' );
+define( __NAMESPACE__ . '\STORY_BOOSTS_PRIORITY', 'civil_publisher_story_boosts_priority' );
+define( __NAMESPACE__ . '\STORY_BOOSTS_PRIORITY_DEFAULT', 5 );
 
 define( __NAMESPACE__ . '\FAQ_HOME', 'https://help.civil.co/hc/en-us/categories/360001540371-Publisher' );
 
@@ -45,6 +47,7 @@ define( __NAMESPACE__ . '\FAQ_HOME', 'https://help.civil.co/hc/en-us/categories/
 define( __NAMESPACE__ . '\TOP_LEVEL_MENU', 'civil-publisher-menu' );
 define( __NAMESPACE__ . '\MANAGEMENT_PAGE', 'civil-publisher-newsroom-management' );
 define( __NAMESPACE__ . '\CONTENT_VIEWER', 'civil-publisher-content' );
+define( __NAMESPACE__ . '\STORY_BOOSTS_SETTINGS', 'civil-publisher-story-boosts-settings' );
 define( __NAMESPACE__ . '\CREDIBILITY_INDICATORS', 'civil-publisher-credibiity-indicators' );
 
 define( __NAMESPACE__ . '\STORY_BOOST_SRC_STAGING', 'https://staging.civil.app/loader/boost.js' );

--- a/classes/class-credibility-indicators.php
+++ b/classes/class-credibility-indicators.php
@@ -187,7 +187,7 @@ class Credibility_Indicators {
 			}
 			?>
 		</div>
-		<p><a href="<?php echo esc_url( menu_page_url( CREDIBILITY_INDICATORS, false ) ); ?>" target="_blank">Settings and more info &#129125;</a></p>
+		<p><a href="<?php echo esc_url( menu_page_url( CREDIBILITY_INDICATORS, false ) ); ?>" target="_blank">Settings and more info</a></p>
 		<?php
 	}
 

--- a/classes/class-credibility-indicators.php
+++ b/classes/class-credibility-indicators.php
@@ -174,7 +174,7 @@ class Credibility_Indicators {
 		wp_nonce_field( 'civil_credibility_indicators', 'civil_credibility_indicators_nonce' );
 		?>
 		<div
-			style="display: flex; flex-direction: column;"
+			style="display: flex; flex-direction: column; margin-bottom: 10px;"
 		>
 			<?php
 			// Output each indicator as a checkbox toggle.
@@ -187,6 +187,7 @@ class Credibility_Indicators {
 			}
 			?>
 		</div>
+		<p><a href="<?php echo esc_url( menu_page_url( CREDIBILITY_INDICATORS, false ) ); ?>" target="_blank">Settings and more info &#129125;</a></p>
 		<?php
 	}
 

--- a/credibililty-indicators.php
+++ b/credibililty-indicators.php
@@ -10,16 +10,22 @@
 	<h1><?php esc_html_e( 'Credibility Indicators', 'civil' ); ?></h1>
 	<p>Credibility Indicators provide readers with greater transparency into the reporting process. On each post you will find a Credibility Indicators section that lets you select which of these, if any, are applicable to the post. Ones you select are also included as metadata when you publish onto the Civil network. You may change the default text below.</p>
 	<p><a href="https://civil.co/credibility-indicators/" target="_blank">Read more about Civil's Credibility Indicators</a></p>
-	<form action="options.php" method="post">
-		<?php
-		// Output security fields.
-		settings_fields( 'civil_credibility_indicators' );
 
-		// Output form fields.
-		do_settings_sections( 'credibility-indicators' );
+	<?php if ( current_user_can( 'manage_options' ) ) { ?>
+		<form action="options.php" method="post">
+			<?php
+			// Output security fields.
+			settings_fields( 'civil_credibility_indicators' );
 
-		// Output save button.
-		submit_button( __( 'Save', 'civil' ) );
-		?>
-	</form>
+			// Output form fields.
+			do_settings_sections( 'credibility-indicators' );
+
+			// Output save button.
+			submit_button( __( 'Save', 'civil' ) );
+			?>
+		</form>
+	<?php } else { ?>
+		<h2><?php esc_html_e( 'Settings', 'civil' ); ?></h2>
+		<p><i><?php esc_html_e( 'You must be an admin in order to edit these settings.', 'civil' ); ?></i></p>
+	<?php } ?>
 </div>

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: civil, journalism, news, blockchain, ethereum, decentralization, permanent
 Requires at least: 4.6
 Tested up to: 5.3
 Requires PHP: 7.0
-Stable tag: 0.7.0
+Stable tag: 0.7.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/story-boosts-settings.php
+++ b/story-boosts-settings.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Story Boosts settings page.
+ *
+ * @package Civil_Publisher
+ */
+?>
+
+<div class="wrap">
+	<h1><?php esc_html_e( 'Story Boosts', 'civil' ); ?></h1>
+	<p>Story boosts are small widgets added to the end of a post that allow readers to support your newsroom with direct payments. Enabled posts will also be submitted to the <a href="https://registry.civil.co/storyfeed" target="_blank">Civil story feed &#129125;</a>.</p>
+	<p>Please contact <a href="mailto:support@civil.co">support@civil.co</a> with any questions or issues.</p>
+
+	<?php if ( current_user_can( 'manage_options' ) ) { ?>
+		<form action="options.php" method="post">
+			<?php
+				settings_fields( 'civil_story_boosts' );
+				do_settings_sections( 'story-boosts' );
+				submit_button( __( 'Save', 'civil' ) );
+			?>
+		</form>
+	<?php } else { ?>
+		<h2><?php esc_html_e( 'Settings', 'civil' ); ?></h2>
+		<p><i><?php esc_html_e( 'You must be an admin in order to edit these settings.', 'civil' ); ?></i></p>
+	<?php } ?>
+</div>

--- a/story-boosts.php
+++ b/story-boosts.php
@@ -41,6 +41,7 @@ function story_boost_meta_box_callback( $post ) {
 		<?php _e( 'Enable Story Boost', 'civil' ); ?>
 	</label>
 	<p style="margin-top: 10px">Embed a small widget to the end of this post that allows readers to support your newsroom with direct payments. If enabled, this post will also be submitted to the <a href="https://registry.civil.co/storyfeed" target="_blank">Civil story feed &#129125;</a>.<!--  <a href="#@TODO/toby" target="_blank">More information</a>.--></p>
+	<p><a href="<?php echo esc_url( menu_page_url( STORY_BOOSTS_SETTINGS, false ) ); ?>" target="_blank">Edit settings</a></p>
 	<?php
 }
 
@@ -72,7 +73,8 @@ add_action( 'save_post', __NAMESPACE__ . '\story_boost_meta_save' );
  */
 function story_boost_loop_start( $query ) {
 	if ( $query->is_main_query() ) {
-		add_action( 'the_content', __NAMESPACE__ . '\story_boost_the_content', 1000 );
+		$priority = intval( get_option( STORY_BOOSTS_PRIORITY, STORY_BOOSTS_PRIORITY_DEFAULT ) );
+		add_action( 'the_content', __NAMESPACE__ . '\story_boost_the_content', $priority );
 		add_action( 'loop_end', __NAMESPACE__ . '\story_boost_loop_end' );
 	}
 }
@@ -82,7 +84,8 @@ add_action( 'loop_start', __NAMESPACE__ . '\story_boost_loop_start' );
  * Clean up Story Boost hooks.
  */
 function story_boost_loop_end() {
-	remove_action( 'the_content', __NAMESPACE__ . '\story_boost_the_content', 1000 );
+	$priority = intval( get_option( STORY_BOOSTS_PRIORITY, STORY_BOOSTS_PRIORITY_DEFAULT ) );
+	remove_action( 'the_content', __NAMESPACE__ . '\story_boost_the_content', $priority );
 }
 
 /**
@@ -102,3 +105,33 @@ function story_boost_the_content( $content ) {
 	}
 	return $content;
 }
+
+/**
+ * Add settings fields to control Story Boosts.
+ */
+function add_settings() {
+	add_settings_section( 'civil_story_boosts', __( 'Settings', 'civil' ), null, 'story-boosts' );
+
+	add_settings_field( STORY_BOOSTS_PRIORITY, __( 'Post Placement Order', 'civil' ), __NAMESPACE__ . '\display_priority_input', 'story-boosts', 'civil_story_boosts' );
+	register_setting( 'civil_story_boosts', STORY_BOOSTS_PRIORITY );
+}
+add_action( 'admin_init', __NAMESPACE__ . '\add_settings' );
+
+/**
+ * Output the priority input.
+ */
+function display_priority_input() {
+	$priority = intval( get_option( STORY_BOOSTS_PRIORITY, STORY_BOOSTS_PRIORITY_DEFAULT ) );
+	?>
+		<div style="max-width: 600px">
+			<input
+				type="number"
+				name="<?php echo esc_attr( STORY_BOOSTS_PRIORITY ); ?>"
+				id="<?php echo esc_attr( STORY_BOOSTS_PRIORITY ); ?>"
+				value="<?php echo esc_attr( $priority ); ?>"
+			/>
+			<p><?php _e( 'Specifies the order in which a Story Boost widget is output at the end of a post, relative to other theme or plugin features which also output things at the end of a post. The lower the number (including negative numbers) the earlier the widget will appear. WordPress default: 10.' ); ?></p>
+		</div>
+	<?php
+}
+

--- a/story-boosts.php
+++ b/story-boosts.php
@@ -40,7 +40,7 @@ function story_boost_meta_box_callback( $post ) {
 		/>
 		<?php _e( 'Enable Story Boost', 'civil' ); ?>
 	</label>
-	<p style="margin-top: 10px">Embed a small widget to the end of this post that allows readers to support your newsroom with direct payments. If enabled, this post will also be submitted to the <a href="https://registry.civil.co/storyfeed" target="_blank">Civil story feed</a>.<!--  <a href="#@TODO/toby" target="_blank">More information</a>.--></p>
+	<p style="margin-top: 10px">Embed a small widget to the end of this post that allows readers to support your newsroom with direct payments. If enabled, this post will also be submitted to the <a href="https://registry.civil.co/storyfeed" target="_blank">Civil story feed &#129125;</a>.<!--  <a href="#@TODO/toby" target="_blank">More information</a>.--></p>
 	<?php
 }
 


### PR DESCRIPTION
Also reduces default from 1000 (don't know why I chose that, makes sense for story boost to come early not late) to 5 (WordPress default is 10).

Also includes some minor updates to Credibility Indicators settings.