### PR TITLE
Initialize DID for newsroom according to did-web spec

### DIFF
--- a/civil-publisher.php
+++ b/civil-publisher.php
@@ -43,6 +43,9 @@ define( __NAMESPACE__ . '\STORY_BOOSTS_PRIORITY', 'civil_publisher_story_boosts_
 define( __NAMESPACE__ . '\STORY_BOOSTS_PRIORITY_DEFAULT', 5 );
 define( __NAMESPACE__ . '\STORY_BOOSTS_ENABLE_BY_DEFAULT', 'civil_publisher_story_boosts_enable_by_default' );
 define( __NAMESPACE__ . '\STORY_BOOSTS_ENABLE_BY_DEFAULT_DEFAULT', false );
+define( __NAMESPACE__ . '\DID_RSA_PUBLIC_KEY', 'civil_publisher_did_public_key' );
+define( __NAMESPACE__ . '\DID_RSA_PRIVATE_KEY', 'civil_publisher_did_private_key' );
+define( __NAMESPACE__ . '\DID_RSA_KEY_ERROR', 'civil_publisher_did_key_error' );
 
 define( __NAMESPACE__ . '\FAQ_HOME', 'https://help.civil.co/hc/en-us/categories/360001540371-Publisher' );
 define( __NAMESPACE__ . '\STORY_BOOSTS_DEBUG_QS_FLAG', 'civil_story_boost_debug' );

--- a/civil-publisher.php
+++ b/civil-publisher.php
@@ -13,6 +13,7 @@
 namespace Civil_Publisher;
 
 define( __NAMESPACE__ . '\PATH', dirname( __FILE__ ) );
+define( __NAMESPACE__ . '\PLUGIN_FILE', __FILE__ );
 define( __NAMESPACE__ . '\REST_API_NAMESPACE', 'civil-publisher/v1' );
 define( __NAMESPACE__ . '\SCHEMA_VERSION', '0.0.1' );
 define( __NAMESPACE__ . '\ASSETS_VERSION', '1.5.2' );
@@ -64,6 +65,7 @@ require_once dirname( __FILE__ ) . '/custom-meta.php';
 require_once dirname( __FILE__ ) . '/admin.php';
 require_once dirname( __FILE__ ) . '/users-page.php';
 require_once dirname( __FILE__ ) . '/story-boosts.php';
+require_once dirname( __FILE__ ) . '/did-vc.php';
 
 if ( is_manager_enabled() ) {
 	require_once dirname( __FILE__ ) . '/classes/class-post-hashing.php';

--- a/classes/class-rest-api.php
+++ b/classes/class-rest-api.php
@@ -114,7 +114,7 @@ class REST_API {
 		if ( ! Post_Hashing::instance()->can_save_hash( $revision->post_parent ) ) {
 			return new \WP_Error(
 				'post-not-published',
-				esc_html__( 'This post revision is not publiushed.' ),
+				esc_html__( 'This post revision is not published.' ),
 				array(
 					'status' => 400,
 				)

--- a/did-doc.php
+++ b/did-doc.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Output DID document.
+ *
+ * @package Civil_Publisher
+ */
+
+namespace Civil_Publisher;
+
+$domain = preg_replace( '/^https?:\/\//', '', get_option( 'siteurl' ) );
+
+echo json_encode(
+	array(
+		'@context' => 'https://w3id.org/did/v1',
+		'id' => "did:web:$domain",
+		'publicKey' => array(
+			array(
+				'id' => "did:web:$domain#owner",
+				'type' => 'Secp256k1VerificationKey2018',
+				'owner' => "did:web:$domain",
+				'publicKeyHex' => '@TODO/tobek get actual pub key',
+			),
+		),
+		'authentication' => array(
+			array(
+				'type' => 'Secp256k1SignatureAuthentication2018',
+				'publicKey' => "did:web:$domain#owner",
+			),
+		),
+	)
+);

--- a/did-doc.php
+++ b/did-doc.php
@@ -16,14 +16,14 @@ echo json_encode(
 		'publicKey' => array(
 			array(
 				'id' => "did:web:$domain#owner",
-				'type' => 'Secp256k1VerificationKey2018',
+				'type' => 'RsaVerificationKey2018',
 				'owner' => "did:web:$domain",
-				'publicKeyHex' => '@TODO/tobek get actual pub key',
+				'publicKeyPem' => get_option( DID_RSA_PUBLIC_KEY ),
 			),
 		),
 		'authentication' => array(
 			array(
-				'type' => 'Secp256k1SignatureAuthentication2018',
+				'type' => 'RsaSignatureAuthentication2018',
 				'publicKey' => "did:web:$domain#owner",
 			),
 		),

--- a/did-vc.php
+++ b/did-vc.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Handles DID and VC logic for ID Hub integration.
+ *
+ * @package Civil_Publisher
+ */
+
+namespace Civil_Publisher;
+
+/**
+ * Init DID logic.
+ */
+function init() {
+	add_filter( 'template_include', __NAMESPACE__ . '\include_template' );
+	add_filter( 'init', __NAMESPACE__ . '\rewrite_rules' );
+}
+
+/**
+ * Override template file for DID doc.
+ *
+ * @param string $template Path of template.
+ */
+function include_template( $template ) {
+	if ( get_query_var( 'civil_publisher_did' ) ) {
+		return PATH . '/did-doc.php';
+	}
+
+	return $template;
+}
+
+/**
+ * Flush rewrite rules.
+ */
+function flush_rules() {
+	$this->rewrite_rules();
+	flush_rewrite_rules();
+}
+
+/**
+ * Set up rewrite rules for DID doc.
+ */
+function rewrite_rules() {
+	add_rewrite_rule( '^\.well-known/did\.json$', 'index.php?civil_publisher_did=true', 'top' );
+	add_rewrite_tag( '%civil_publisher_did%', '*' );
+}
+
+add_action( 'plugins_loaded', __NAMESPACE__ . '\init' );
+
+// On plugin activation flush rewrite rules.
+register_activation_hook( PLUGIN_FILE, __NAMESPACE__ . '\flush_rules' );
+

--- a/did-vc.php
+++ b/did-vc.php
@@ -13,6 +13,43 @@ namespace Civil_Publisher;
 function init() {
 	add_filter( 'template_include', __NAMESPACE__ . '\include_template' );
 	add_filter( 'init', __NAMESPACE__ . '\rewrite_rules' );
+
+	if ( current_user_can( 'manage_options' ) && empty( get_option( DID_RSA_PRIVATE_KEY ) ) ) {
+		try {
+			init_key_pair();
+		} catch ( Exception $e ) {
+			// @TODO/tobek Surface this error in admin. If missing openssl configs are a problem in the wild, consider using phpseclib instead.
+			update_option( DID_RSA_KEY_ERROR, 'Failed to generate openssl key pair: ' . $e->getMessage() );
+		}
+	}
+}
+
+/**
+ * Init DID key pair and save in database.
+ *
+ * Note that we store the DID private key in plain text in the database. This is of course awfully insecure, but if we want to be able to publish VCs without user interaction then the plugin needs access to the private key somehow. We could do various things to superficially harden the key but they are all either too brittle (e.g. using user's login password as encryption key would break if user loses password and resets it, while using wp-config.php salts as encryption key would break if user migrates to a new WP install) or trivial to defeat (storing encryption key in plugin to encrypt value stored in DB sounds nice, but anyone with access to the DB could trivially google the option name and find this open source plugin and decrypt from there). Even something fancy that required user-held secrets and user interaction for every action (e.g. signing in metamask) could be vulnerable to spoofed requests if the site is compromised. Fundamentally this private key does not protect anything special at the moment; it's more of an identifier. This can be revisited in the future.
+ */
+function init_key_pair() {
+	$key = openssl_pkey_new(
+		array(
+			'digest_alg' => 'sha512',
+			'private_key_bits' => 4096,
+			'private_key_type' => OPENSSL_KEYTYPE_RSA,
+		)
+	);
+
+	openssl_pkey_export( $key, $private_key );
+
+	$public_key = openssl_pkey_get_details( $key );
+	$public_key = $public_key['key'];
+
+	if ( $private_key && $public_key ) {
+		delete_option( DID_RSA_KEY_ERROR );
+		update_option( DID_RSA_PRIVATE_KEY, $private_key );
+		update_option( DID_RSA_PUBLIC_KEY, $public_key );
+	} else {
+		update_option( DID_RSA_KEY_ERROR, 'Failed to generate openssl key pair: generated keys are falsey.' );
+	}
 }
 
 /**

--- a/utils.php
+++ b/utils.php
@@ -34,7 +34,7 @@ function get_civil_post_types() {
 /**
  * Checks if the currently-logged-in-user can sign posts with the plugin.
  *
- * @return bool Whether or not tthey can sign.
+ * @return bool Whether or not they can sign.
  */
 function current_user_can_sign_posts() {
 	// If user can't edit published posts, then they can't sign any updates to their posts, so rather than let them sign drafts and have invalid (and removed) signature on anly published updates, don't let them sign at all (until we have some way to add signatures outside of the edit post context).


### PR DESCRIPTION
This creates a DID for the newsroom and serves it at `/.well-known/did.json`.

I ended up not able to do a secp256k1, since all the PHP libraries that support generating new key pairs require that PHP be compiled with non-standard libraries enabled, and there's no way to guarantee this will work on WordPress installations in the wild.

The DID spec [supports various signature methods](https://w3c-ccg.github.io/ld-cryptosuite-registry/), one of which is RSA, which is more accessible from PHP, so I'm using that here.

If this is an issue, we can look into generating secp256k1 in the browser with this pure-JS library https://github.com/libp2p/js-libp2p-crypto-secp256k1 instead.

I was going to do some basic hardening of the private key stored in DB, and actually got it working (db9fda1a0d3ec51e16516431c7cd33ecb7be7887) but realized it would be utterly trivial to defeat (see my comment on that commit) so I think it's not worth doing that and I haven't included it in this PR.