### PR TITLE
VC Explorer POC

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -47,8 +47,17 @@ function add_menus() {
 		__( 'Story Boosts', 'civil' ),
 		__( 'Story Boosts', 'civil' ),
 		'edit_posts',
-		STORY_BOOSTS_SETTINGS,
+		STORY_BOOSTS_SETTINGS_PAGE,
 		__NAMESPACE__ . '\story_boosts_settings_content'
+	);
+
+	add_submenu_page(
+		TOP_LEVEL_MENU,
+		__( 'Decentralized Identity Tools', 'civil' ),
+		__( 'Decentralized Identity Tools', 'civil' ),
+		'manage_options',
+		DID_SETTINGS_PAGE,
+		__NAMESPACE__ . '\did_settings_content'
 	);
 
 	if ( apply_filters( 'civil_enable_credibility_indicators', true ) ) {
@@ -126,6 +135,13 @@ function help_menu_content() {
  */
 function story_boosts_settings_content() {
 	require_once dirname( __FILE__ ) . '/story-boosts-settings.php';
+}
+
+/**
+ * DID Settings content.
+ */
+function did_settings_content() {
+	require_once dirname( __FILE__ ) . '/did-settings.php';
 }
 
 /**

--- a/civil-publisher.php
+++ b/civil-publisher.php
@@ -47,6 +47,7 @@ define( __NAMESPACE__ . '\DID_IS_ENABLED_OPTION_KEY', 'civil_publisher_did_is_en
 define( __NAMESPACE__ . '\DID_IS_ENABLED_DEFAULT', true );
 define( __NAMESPACE__ . '\DID_ERROR_OPTION_KEY', 'civil_publisher_did_error' );
 define( __NAMESPACE__ . '\ASSIGNED_DID_OPTION_KEY', 'civil_publisher_assigned_did' );
+define( __NAMESPACE__ . '\VC_LOG_OPTION_KEY', 'civil_publisher_vc_log' );
 
 define( __NAMESPACE__ . '\FAQ_HOME', 'https://help.civil.co/hc/en-us/categories/360001540371-Publisher' );
 define( __NAMESPACE__ . '\STORY_BOOSTS_DEBUG_QS_FLAG', 'civil_story_boost_debug' );
@@ -73,6 +74,7 @@ require_once dirname( __FILE__ ) . '/admin.php';
 require_once dirname( __FILE__ ) . '/users-page.php';
 require_once dirname( __FILE__ ) . '/story-boosts.php';
 require_once dirname( __FILE__ ) . '/did-vc.php';
+require_once dirname( __FILE__ ) . '/classes/class-post-vc-gen.php';
 
 if ( is_manager_enabled() ) {
 	require_once dirname( __FILE__ ) . '/classes/class-post-hashing.php';

--- a/civil-publisher.php
+++ b/civil-publisher.php
@@ -46,6 +46,7 @@ define( __NAMESPACE__ . '\STORY_BOOSTS_ENABLE_BY_DEFAULT_DEFAULT', false );
 define( __NAMESPACE__ . '\OPTION_DID_IS_ENABLED', 'civil_publisher_did_is_enabled' );
 define( __NAMESPACE__ . '\DID_IS_ENABLED_DEFAULT', true );
 define( __NAMESPACE__ . '\OPTION_DID_ERROR', 'civil_publisher_did_error' );
+define( __NAMESPACE__ . '\OPTION_ASSIGNED_DID', 'civil_publisher_assigned_did' );
 
 define( __NAMESPACE__ . '\FAQ_HOME', 'https://help.civil.co/hc/en-us/categories/360001540371-Publisher' );
 define( __NAMESPACE__ . '\STORY_BOOSTS_DEBUG_QS_FLAG', 'civil_story_boost_debug' );
@@ -60,6 +61,8 @@ define( __NAMESPACE__ . '\CREDIBILITY_INDICATORS', 'civil-publisher-credibiity-i
 
 define( __NAMESPACE__ . '\STORY_BOOST_SRC_STAGING', 'https://staging.civil.app/loader/boost.js' );
 define( __NAMESPACE__ . '\STORY_BOOST_SRC_PROD', 'https://registry.civil.co/loader/boost.js' );
+
+define( __NAMESPACE__ . '\DID_AGENT_BASE_URL', 'http://10.0.2.2:3000' );
 
 require_once dirname( __FILE__ ) . '/utils.php';
 

--- a/civil-publisher.php
+++ b/civil-publisher.php
@@ -12,59 +12,59 @@
 
 namespace Civil_Publisher;
 
-define( __NAMESPACE__ . '\PATH', dirname( __FILE__ ) );
-define( __NAMESPACE__ . '\PLUGIN_FILE', __FILE__ );
-define( __NAMESPACE__ . '\REST_API_NAMESPACE', 'civil-publisher/v1' );
-define( __NAMESPACE__ . '\SCHEMA_VERSION', '0.0.1' );
-define( __NAMESPACE__ . '\ASSETS_VERSION', '1.5.2' );
+const CIVIL_FIRST_FLEET_STATIC_VERSION = '1.0.3';
+const PLUGIN_FILE = __FILE__;
+const REST_API_NAMESPACE = 'civil-publisher/v1';
+const SCHEMA_VERSION = '0.0.1';
+const ASSETS_VERSION = '1.5.2';
 
 // Post meta.
-define( __NAMESPACE__ . '\REVISION_HASH_META_KEY', 'civil_publisher_revision_hash' );
-define( __NAMESPACE__ . '\REVISION_DATA_META_KEY', 'civil_publisher_revision_extra_data' );
-define( __NAMESPACE__ . '\SIGNATURES_META_KEY', 'civil_publisher_article_signatures' );
-define( __NAMESPACE__ . '\REVISIONS_META_KEY', 'civil_publisher_published_revisions' );
-define( __NAMESPACE__ . '\TXHASH_META_KEY', 'civil_publisher_publish_tx_hash' );
-define( __NAMESPACE__ . '\IPFS_META_KEY', 'civil_publisher_publish_ipfs' );
-define( __NAMESPACE__ . '\ARCHIVE_STATUS_META_KEY', 'civil_publisher_publish_archive_status' );
-define( __NAMESPACE__ . '\CONTENT_ID_META_KEY', 'civil_publisher_content_id' );
-define( __NAMESPACE__ . '\POST_AUTHORS_META_KEY', 'civil_publisher_post_authors' );
-define( __NAMESPACE__ . '\SHOW_STORY_BOOST_META_KEY', 'civil_publisher_show_story_boost' );
+const REVISION_HASH_META_KEY = 'civil_publisher_revision_hash';
+const REVISION_DATA_META_KEY = 'civil_publisher_revision_extra_data';
+const SIGNATURES_META_KEY = 'civil_publisher_article_signatures';
+const REVISIONS_META_KEY = 'civil_publisher_published_revisions';
+const TXHASH_META_KEY = 'civil_publisher_publish_tx_hash';
+const IPFS_META_KEY = 'civil_publisher_publish_ipfs';
+const ARCHIVE_STATUS_META_KEY = 'civil_publisher_publish_archive_status';
+const CONTENT_ID_META_KEY = 'civil_publisher_content_id';
+const POST_AUTHORS_META_KEY = 'civil_publisher_post_authors';
+const SHOW_STORY_BOOST_META_KEY = 'civil_publisher_show_story_boost';
 
 // User meta.
-define( __NAMESPACE__ . '\USER_ETH_ADDRESS_META_KEY', 'civil_publisher_eth_wallet_address' );
-define( __NAMESPACE__ . '\USER_NEWSROOM_ROLE_META_KEY', 'civil_publisher_newsroom_role' );
+const USER_ETH_ADDRESS_META_KEY = 'civil_publisher_eth_wallet_address';
+const USER_NEWSROOM_ROLE_META_KEY = 'civil_publisher_newsroom_role';
 
 // Site options.
-define( __NAMESPACE__ . '\NEWSROOM_ADDRESS_OPTION_KEY', 'civil_publisher_newsroom_address' );
-define( __NAMESPACE__ . '\NEWSROOM_TXHASH_OPTION_KEY', 'civil_publisher_newsroom_txhash' );
-define( __NAMESPACE__ . '\NEWSROOM_CHARTER_OPTION_KEY', 'civil_publisher_newsroom_charter' );
-define( __NAMESPACE__ . '\NETWORK_NAME_OPTION_KEY', 'civil_publisher_network_name' );
-define( __NAMESPACE__ . '\STORY_BOOSTS_PRIORITY', 'civil_publisher_story_boosts_priority' );
-define( __NAMESPACE__ . '\STORY_BOOSTS_PRIORITY_DEFAULT', 5 );
-define( __NAMESPACE__ . '\STORY_BOOSTS_ENABLE_BY_DEFAULT', 'civil_publisher_story_boosts_enable_by_default' );
-define( __NAMESPACE__ . '\STORY_BOOSTS_ENABLE_BY_DEFAULT_DEFAULT', false );
+const NEWSROOM_ADDRESS_OPTION_KEY = 'civil_publisher_newsroom_address';
+const NEWSROOM_TXHASH_OPTION_KEY = 'civil_publisher_newsroom_txhash';
+const NEWSROOM_CHARTER_OPTION_KEY = 'civil_publisher_newsroom_charter';
+const NETWORK_NAME_OPTION_KEY = 'civil_publisher_network_name';
+const STORY_BOOSTS_PRIORITY = 'civil_publisher_story_boosts_priority';
+const STORY_BOOSTS_PRIORITY_DEFAULT = 5;
+const STORY_BOOSTS_ENABLE_BY_DEFAULT = 'civil_publisher_story_boosts_enable_by_default';
+const STORY_BOOSTS_ENABLE_BY_DEFAULT_DEFAULT = false;
 
-define( __NAMESPACE__ . '\DID_IS_ENABLED_OPTION_KEY', 'civil_publisher_did_is_enabled' );
-define( __NAMESPACE__ . '\DID_IS_ENABLED_DEFAULT', true );
-define( __NAMESPACE__ . '\DID_ERROR_OPTION_KEY', 'civil_publisher_did_error' );
-define( __NAMESPACE__ . '\ASSIGNED_DID_OPTION_KEY', 'civil_publisher_assigned_did' );
-define( __NAMESPACE__ . '\VC_LOG_OPTION_KEY', 'civil_publisher_vc_log' );
-define( __NAMESPACE__ . '\DID_AGENT_BASE_URL_OPTION_KEY', 'civil_publisher_did_agent_base_url' );
-define( __NAMESPACE__ . '\DID_AGENT_BASE_URL_DEFAULT', 'http://10.0.2.2:3000' );
+const DID_IS_ENABLED_OPTION_KEY = 'civil_publisher_did_is_enabled';
+const DID_IS_ENABLED_DEFAULT = true;
+const DID_ERROR_OPTION_KEY = 'civil_publisher_did_error';
+const ASSIGNED_DID_OPTION_KEY = 'civil_publisher_assigned_did';
+const VC_LOG_OPTION_KEY = 'civil_publisher_vc_log';
+const DID_AGENT_BASE_URL_OPTION_KEY = 'civil_publisher_did_agent_base_url';
+const DID_AGENT_BASE_URL_DEFAULT = 'http://10.0.2.2:3000';
 
-define( __NAMESPACE__ . '\FAQ_HOME', 'https://help.civil.co/hc/en-us/categories/360001540371-Publisher' );
-define( __NAMESPACE__ . '\STORY_BOOSTS_DEBUG_QS_FLAG', 'civil_story_boost_debug' );
+const FAQ_HOME = 'https://help.civil.co/hc/en-us/categories/360001540371-Publisher';
+const STORY_BOOSTS_DEBUG_QS_FLAG = 'civil_story_boost_debug';
 
 // Menus.
-define( __NAMESPACE__ . '\TOP_LEVEL_MENU', 'civil-publisher-menu' );
-define( __NAMESPACE__ . '\MANAGEMENT_PAGE', 'civil-publisher-newsroom-management' );
-define( __NAMESPACE__ . '\CONTENT_VIEWER', 'civil-publisher-content' );
-define( __NAMESPACE__ . '\STORY_BOOSTS_SETTINGS_PAGE', 'civil-publisher-story-boosts-settings' );
-define( __NAMESPACE__ . '\DID_SETTINGS_PAGE', 'civil-publisher-did-settings' );
-define( __NAMESPACE__ . '\CREDIBILITY_INDICATORS', 'civil-publisher-credibiity-indicators' );
+const TOP_LEVEL_MENU = 'civil-publisher-menu';
+const MANAGEMENT_PAGE = 'civil-publisher-newsroom-management';
+const CONTENT_VIEWER = 'civil-publisher-content';
+const STORY_BOOSTS_SETTINGS_PAGE = 'civil-publisher-story-boosts-settings';
+const DID_SETTINGS_PAGE = 'civil-publisher-did-settings';
+const CREDIBILITY_INDICATORS = 'civil-publisher-credibiity-indicators';
 
-define( __NAMESPACE__ . '\STORY_BOOST_SRC_STAGING', 'https://staging.civil.app/loader/boost.js' );
-define( __NAMESPACE__ . '\STORY_BOOST_SRC_PROD', 'https://registry.civil.co/loader/boost.js' );
+const STORY_BOOST_SRC_STAGING = 'https://staging.civil.app/loader/boost.js';
+const STORY_BOOST_SRC_PROD = 'https://registry.civil.co/loader/boost.js';
 
 require_once dirname( __FILE__ ) . '/utils.php';
 

--- a/civil-publisher.php
+++ b/civil-publisher.php
@@ -51,6 +51,11 @@ const ASSIGNED_DID_OPTION_KEY = 'civil_publisher_assigned_did';
 const VC_LOG_OPTION_KEY = 'civil_publisher_vc_log';
 const DID_AGENT_BASE_URL_OPTION_KEY = 'civil_publisher_did_agent_base_url';
 const DID_AGENT_BASE_URL_DEFAULT = 'http://10.0.2.2:3000';
+const PUB_VC_BY_DEFAULT_ON_NEW_OPTION_KEY = 'civil_publisher_pub_vc_by_default_on_new';
+const PUB_VC_BY_DEFAULT_ON_NEW_DEFAULT = true;
+const PUB_VC_BY_DEFAULT_ON_UPDATE_OPTION_KEY = 'civil_publisher_pub_vc_by_default_on_update';
+const PUB_VC_BY_DEFAULT_ON_UPDATE_DEFAULT = false;
+const PUB_VC_POST_KEY = 'civil_publisher_pub_vc';
 
 const FAQ_HOME = 'https://help.civil.co/hc/en-us/categories/360001540371-Publisher';
 const STORY_BOOSTS_DEBUG_QS_FLAG = 'civil_story_boost_debug';
@@ -73,9 +78,9 @@ require_once dirname( __FILE__ ) . '/traits/trait-singleton.php';
 require_once dirname( __FILE__ ) . '/custom-meta.php';
 require_once dirname( __FILE__ ) . '/admin.php';
 require_once dirname( __FILE__ ) . '/users-page.php';
-require_once dirname( __FILE__ ) . '/story-boosts.php';
 require_once dirname( __FILE__ ) . '/did-vc.php';
-require_once dirname( __FILE__ ) . '/classes/class-post-vc-gen.php';
+require_once dirname( __FILE__ ) . '/classes/class-post-vc-pub.php';
+require_once dirname( __FILE__ ) . '/story-boosts.php';
 
 if ( is_manager_enabled() ) {
 	require_once dirname( __FILE__ ) . '/classes/class-post-hashing.php';

--- a/civil-publisher.php
+++ b/civil-publisher.php
@@ -43,6 +43,9 @@ define( __NAMESPACE__ . '\STORY_BOOSTS_PRIORITY', 'civil_publisher_story_boosts_
 define( __NAMESPACE__ . '\STORY_BOOSTS_PRIORITY_DEFAULT', 5 );
 define( __NAMESPACE__ . '\STORY_BOOSTS_ENABLE_BY_DEFAULT', 'civil_publisher_story_boosts_enable_by_default' );
 define( __NAMESPACE__ . '\STORY_BOOSTS_ENABLE_BY_DEFAULT_DEFAULT', false );
+define( __NAMESPACE__ . '\DID_RSA_PUBLIC_KEY', 'civil_publisher_did_public_key' );
+define( __NAMESPACE__ . '\DID_RSA_PRIVATE_KEY', 'civil_publisher_did_private_key' );
+define( __NAMESPACE__ . '\DID_RSA_KEY_ERROR', 'civil_publisher_did_key_error' );
 
 define( __NAMESPACE__ . '\FAQ_HOME', 'https://help.civil.co/hc/en-us/categories/360001540371-Publisher' );
 define( __NAMESPACE__ . '\STORY_BOOSTS_DEBUG_QS_FLAG', 'civil_story_boost_debug' );

--- a/civil-publisher.php
+++ b/civil-publisher.php
@@ -43,9 +43,11 @@ define( __NAMESPACE__ . '\STORY_BOOSTS_PRIORITY', 'civil_publisher_story_boosts_
 define( __NAMESPACE__ . '\STORY_BOOSTS_PRIORITY_DEFAULT', 5 );
 define( __NAMESPACE__ . '\STORY_BOOSTS_ENABLE_BY_DEFAULT', 'civil_publisher_story_boosts_enable_by_default' );
 define( __NAMESPACE__ . '\STORY_BOOSTS_ENABLE_BY_DEFAULT_DEFAULT', false );
-define( __NAMESPACE__ . '\DID_RSA_PUBLIC_KEY', 'civil_publisher_did_public_key' );
-define( __NAMESPACE__ . '\DID_RSA_PRIVATE_KEY', 'civil_publisher_did_private_key' );
-define( __NAMESPACE__ . '\DID_RSA_KEY_ERROR', 'civil_publisher_did_key_error' );
+define( __NAMESPACE__ . '\OPTION_DID_IS_ENABLED', 'civil_publisher_did_is_enabled' );
+define( __NAMESPACE__ . '\DID_IS_ENABLED_DEFAULT', true );
+define( __NAMESPACE__ . '\OPTION_DID_RSA_PUBLIC_KEY', 'civil_publisher_did_public_key' );
+define( __NAMESPACE__ . '\OPTION_DID_RSA_PRIVATE_KEY', 'civil_publisher_did_private_key' );
+define( __NAMESPACE__ . '\OPTION_DID_RSA_KEY_ERROR', 'civil_publisher_did_key_error' );
 
 define( __NAMESPACE__ . '\FAQ_HOME', 'https://help.civil.co/hc/en-us/categories/360001540371-Publisher' );
 define( __NAMESPACE__ . '\STORY_BOOSTS_DEBUG_QS_FLAG', 'civil_story_boost_debug' );
@@ -54,7 +56,8 @@ define( __NAMESPACE__ . '\STORY_BOOSTS_DEBUG_QS_FLAG', 'civil_story_boost_debug'
 define( __NAMESPACE__ . '\TOP_LEVEL_MENU', 'civil-publisher-menu' );
 define( __NAMESPACE__ . '\MANAGEMENT_PAGE', 'civil-publisher-newsroom-management' );
 define( __NAMESPACE__ . '\CONTENT_VIEWER', 'civil-publisher-content' );
-define( __NAMESPACE__ . '\STORY_BOOSTS_SETTINGS', 'civil-publisher-story-boosts-settings' );
+define( __NAMESPACE__ . '\STORY_BOOSTS_SETTINGS_PAGE', 'civil-publisher-story-boosts-settings' );
+define( __NAMESPACE__ . '\DID_SETTINGS_PAGE', 'civil-publisher-did-settings' );
 define( __NAMESPACE__ . '\CREDIBILITY_INDICATORS', 'civil-publisher-credibiity-indicators' );
 
 define( __NAMESPACE__ . '\STORY_BOOST_SRC_STAGING', 'https://staging.civil.app/loader/boost.js' );

--- a/civil-publisher.php
+++ b/civil-publisher.php
@@ -13,6 +13,7 @@
 namespace Civil_Publisher;
 
 define( __NAMESPACE__ . '\PATH', dirname( __FILE__ ) );
+define( __NAMESPACE__ . '\PLUGIN_FILE', __FILE__ );
 define( __NAMESPACE__ . '\REST_API_NAMESPACE', 'civil-publisher/v1' );
 define( __NAMESPACE__ . '\SCHEMA_VERSION', '0.0.1' );
 define( __NAMESPACE__ . '\ASSETS_VERSION', '1.5.2' );
@@ -64,6 +65,7 @@ require_once dirname( __FILE__ ) . '/custom-meta.php';
 require_once dirname( __FILE__ ) . '/admin.php';
 require_once dirname( __FILE__ ) . '/users-page.php';
 require_once dirname( __FILE__ ) . '/story-boosts.php';
+require_once dirname( __FILE__ ) . '/did-vc.php';
 
 if ( is_manager_enabled() ) {
 	require_once dirname( __FILE__ ) . '/classes/class-post-hashing.php';

--- a/civil-publisher.php
+++ b/civil-publisher.php
@@ -30,6 +30,7 @@ const CONTENT_ID_META_KEY = 'civil_publisher_content_id';
 const POST_AUTHORS_META_KEY = 'civil_publisher_post_authors';
 const SHOW_STORY_BOOST_META_KEY = 'civil_publisher_show_story_boost';
 const POST_UUID_META_KEY = 'civil_publisher_post_uuid';
+const LAST_VC_PUB_DATE_META_KEY = 'civil_publisher_last_vc_pub_date';
 
 // User meta.
 const USER_ETH_ADDRESS_META_KEY = 'civil_publisher_eth_wallet_address';

--- a/civil-publisher.php
+++ b/civil-publisher.php
@@ -45,9 +45,7 @@ define( __NAMESPACE__ . '\STORY_BOOSTS_ENABLE_BY_DEFAULT', 'civil_publisher_stor
 define( __NAMESPACE__ . '\STORY_BOOSTS_ENABLE_BY_DEFAULT_DEFAULT', false );
 define( __NAMESPACE__ . '\OPTION_DID_IS_ENABLED', 'civil_publisher_did_is_enabled' );
 define( __NAMESPACE__ . '\DID_IS_ENABLED_DEFAULT', true );
-define( __NAMESPACE__ . '\OPTION_DID_RSA_PUBLIC_KEY', 'civil_publisher_did_public_key' );
-define( __NAMESPACE__ . '\OPTION_DID_RSA_PRIVATE_KEY', 'civil_publisher_did_private_key' );
-define( __NAMESPACE__ . '\OPTION_DID_RSA_KEY_ERROR', 'civil_publisher_did_key_error' );
+define( __NAMESPACE__ . '\OPTION_DID_ERROR', 'civil_publisher_did_error' );
 
 define( __NAMESPACE__ . '\FAQ_HOME', 'https://help.civil.co/hc/en-us/categories/360001540371-Publisher' );
 define( __NAMESPACE__ . '\STORY_BOOSTS_DEBUG_QS_FLAG', 'civil_story_boost_debug' );

--- a/civil-publisher.php
+++ b/civil-publisher.php
@@ -43,10 +43,10 @@ define( __NAMESPACE__ . '\STORY_BOOSTS_PRIORITY', 'civil_publisher_story_boosts_
 define( __NAMESPACE__ . '\STORY_BOOSTS_PRIORITY_DEFAULT', 5 );
 define( __NAMESPACE__ . '\STORY_BOOSTS_ENABLE_BY_DEFAULT', 'civil_publisher_story_boosts_enable_by_default' );
 define( __NAMESPACE__ . '\STORY_BOOSTS_ENABLE_BY_DEFAULT_DEFAULT', false );
-define( __NAMESPACE__ . '\OPTION_DID_IS_ENABLED', 'civil_publisher_did_is_enabled' );
+define( __NAMESPACE__ . '\DID_IS_ENABLED_OPTION_KEY', 'civil_publisher_did_is_enabled' );
 define( __NAMESPACE__ . '\DID_IS_ENABLED_DEFAULT', true );
-define( __NAMESPACE__ . '\OPTION_DID_ERROR', 'civil_publisher_did_error' );
-define( __NAMESPACE__ . '\OPTION_ASSIGNED_DID', 'civil_publisher_assigned_did' );
+define( __NAMESPACE__ . '\DID_ERROR_OPTION_KEY', 'civil_publisher_did_error' );
+define( __NAMESPACE__ . '\ASSIGNED_DID_OPTION_KEY', 'civil_publisher_assigned_did' );
 
 define( __NAMESPACE__ . '\FAQ_HOME', 'https://help.civil.co/hc/en-us/categories/360001540371-Publisher' );
 define( __NAMESPACE__ . '\STORY_BOOSTS_DEBUG_QS_FLAG', 'civil_story_boost_debug' );

--- a/civil-publisher.php
+++ b/civil-publisher.php
@@ -29,6 +29,7 @@ const ARCHIVE_STATUS_META_KEY = 'civil_publisher_publish_archive_status';
 const CONTENT_ID_META_KEY = 'civil_publisher_content_id';
 const POST_AUTHORS_META_KEY = 'civil_publisher_post_authors';
 const SHOW_STORY_BOOST_META_KEY = 'civil_publisher_show_story_boost';
+const POST_UUID_META_KEY = 'civil_publisher_post_uuid';
 
 // User meta.
 const USER_ETH_ADDRESS_META_KEY = 'civil_publisher_eth_wallet_address';
@@ -55,10 +56,10 @@ const PUB_VC_BY_DEFAULT_ON_NEW_OPTION_KEY = 'civil_publisher_pub_vc_by_default_o
 const PUB_VC_BY_DEFAULT_ON_NEW_DEFAULT = true;
 const PUB_VC_BY_DEFAULT_ON_UPDATE_OPTION_KEY = 'civil_publisher_pub_vc_by_default_on_update';
 const PUB_VC_BY_DEFAULT_ON_UPDATE_DEFAULT = false;
-const PUB_VC_POST_KEY = 'civil_publisher_pub_vc';
 
-const FAQ_HOME = 'https://help.civil.co/hc/en-us/categories/360001540371-Publisher';
 const STORY_BOOSTS_DEBUG_QS_FLAG = 'civil_story_boost_debug';
+const PUB_VC_POST_FLAG = 'civil_publisher_pub_vc';
+const UUID_PERMALINK_QUERY = 'civil_publisher_uuid';
 
 // Menus.
 const TOP_LEVEL_MENU = 'civil-publisher-menu';
@@ -68,6 +69,7 @@ const STORY_BOOSTS_SETTINGS_PAGE = 'civil-publisher-story-boosts-settings';
 const DID_SETTINGS_PAGE = 'civil-publisher-did-settings';
 const CREDIBILITY_INDICATORS = 'civil-publisher-credibiity-indicators';
 
+const FAQ_HOME = 'https://help.civil.co/hc/en-us/categories/360001540371-Publisher';
 const STORY_BOOST_SRC_STAGING = 'https://staging.civil.app/loader/boost.js';
 const STORY_BOOST_SRC_PROD = 'https://registry.civil.co/loader/boost.js';
 

--- a/civil-publisher.php
+++ b/civil-publisher.php
@@ -3,7 +3,7 @@
  * Plugin Name: Civil Publisher Tools
  * Plugin URI: https://github.com/joincivil/civil-publisher-wordpress-plugin
  * Description: Use Civil's growing suite of publisher tools, including: Boosts, to let readers easily support to your newsroom from any article; Credibility Indicators, to educate readers about what work goes into good journalism, and our smart contract tools (experimental) to publish and archive content on the Ethereum blockchain.
- * Version: 1.0.0
+ * Version: 1.1.0
  * Author: Civil
  * Author URI: https://civil.co
  *
@@ -43,11 +43,14 @@ define( __NAMESPACE__ . '\STORY_BOOSTS_PRIORITY', 'civil_publisher_story_boosts_
 define( __NAMESPACE__ . '\STORY_BOOSTS_PRIORITY_DEFAULT', 5 );
 define( __NAMESPACE__ . '\STORY_BOOSTS_ENABLE_BY_DEFAULT', 'civil_publisher_story_boosts_enable_by_default' );
 define( __NAMESPACE__ . '\STORY_BOOSTS_ENABLE_BY_DEFAULT_DEFAULT', false );
+
 define( __NAMESPACE__ . '\DID_IS_ENABLED_OPTION_KEY', 'civil_publisher_did_is_enabled' );
 define( __NAMESPACE__ . '\DID_IS_ENABLED_DEFAULT', true );
 define( __NAMESPACE__ . '\DID_ERROR_OPTION_KEY', 'civil_publisher_did_error' );
 define( __NAMESPACE__ . '\ASSIGNED_DID_OPTION_KEY', 'civil_publisher_assigned_did' );
 define( __NAMESPACE__ . '\VC_LOG_OPTION_KEY', 'civil_publisher_vc_log' );
+define( __NAMESPACE__ . '\DID_AGENT_BASE_URL_OPTION_KEY', 'civil_publisher_did_agent_base_url' );
+define( __NAMESPACE__ . '\DID_AGENT_BASE_URL_DEFAULT', 'http://10.0.2.2:3000' );
 
 define( __NAMESPACE__ . '\FAQ_HOME', 'https://help.civil.co/hc/en-us/categories/360001540371-Publisher' );
 define( __NAMESPACE__ . '\STORY_BOOSTS_DEBUG_QS_FLAG', 'civil_story_boost_debug' );
@@ -62,8 +65,6 @@ define( __NAMESPACE__ . '\CREDIBILITY_INDICATORS', 'civil-publisher-credibiity-i
 
 define( __NAMESPACE__ . '\STORY_BOOST_SRC_STAGING', 'https://staging.civil.app/loader/boost.js' );
 define( __NAMESPACE__ . '\STORY_BOOST_SRC_PROD', 'https://registry.civil.co/loader/boost.js' );
-
-define( __NAMESPACE__ . '\DID_AGENT_BASE_URL', 'http://10.0.2.2:3000' );
 
 require_once dirname( __FILE__ ) . '/utils.php';
 

--- a/classes/class-post-hashing.php
+++ b/classes/class-post-hashing.php
@@ -34,7 +34,7 @@ class Post_Hashing {
 	 */
 	public function hash( string $content ) : string {
 		// Include the hashing library.
-		require_once PATH . '/lib/php-keccak/Keccak.php';
+		require_once dirname( PLUGIN_FILE ) . '/lib/php-keccak/Keccak.php';
 
 		return '0x' . \kornrunner\Keccak::hash( $content, '256' );
 	}

--- a/classes/class-post-vc-gen.php
+++ b/classes/class-post-vc-gen.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Hanldes all logic related to generating VCs for posts.
+ *
+ * @package Civil_Publisher
+ */
+
+namespace Civil_Publisher;
+
+/**
+ * The Post_VC_Gen class.
+ */
+class Post_VC_Gen {
+	use Singleton;
+
+	/**
+	 * Setup the class.
+	 */
+	public function setup() {
+		add_action( 'save_post', array( $this, 'generate_vc' ) );
+	}
+
+	/**
+	 * Checks if we should generate a VC for this post
+	 *
+	 * @param int $post_id The post ID.
+	 * @return bool Whether or not to generate a VC.
+	 */
+	public function should_gen_vc( $post_id ) : bool {
+		$should_gen = true;
+
+		// Only generate VCs for supported post types.
+		if ( ! in_array( get_post_type( $post_id ), get_civil_post_types(), true ) ) {
+			$should_gen = false;
+		}
+
+		/**
+		 * Filters whether or not to generate a VC.
+		 *
+		 * @param bool $should_gen Should we generate VC?
+		 * @param int  $post_id  The post ID.
+		 */
+		return apply_filters( 'civil_publisher_should_gen_vc', $should_gen, $post_id );
+	}
+
+	/**
+	 * Generate a VC for this post.
+	 *
+	 * @param int $post_id The post ID.
+	 */
+	public function generate_vc( $post_id ) {
+		$post = get_post( $post_id );
+
+		if ( ! ( $post instanceof \WP_Post ) ) {
+			return;
+		} else if ( ! isset( $post->post_status ) || 'publish' != $post->post_status ) {
+			return;
+		} else if ( wp_is_post_autosave( $post_id ) || wp_is_post_revision( $post_id ) ) {
+			return;
+		} else if ( ! $this->should_gen_vc( $post->ID ) ) {
+			return;
+		}
+
+		$primary_category    = '';
+		$primary_category_id = get_post_meta( $post->ID, 'primary_category_id', true );
+
+		if ( ! empty( $primary_category_id ) ) {
+			$primary_category_term = get_term_by( 'id', $primary_category_id, 'category' );
+
+			if ( $primary_category_term instanceof \WP_Term ) {
+				$primary_category = $primary_category_term->slug;
+			}
+		}
+
+		$json_payload_data = array(
+			'contributors'          => $this->get_contributor_data( $post ),
+			'tags'                  => wp_get_post_tags( $post->ID, array( 'fields' => 'slugs' ) ),
+			'primaryTag'            => $primary_category,
+		);
+
+		// @TODO/tobek Now generate VC.
+	}
+
+	/**
+	 * Get contributor (authors, editors, others in the future) data for given post
+	 *
+	 * @param object $post A WP_Post object.
+	 * @return array List of data for each contributor on post.
+	 */
+	public function get_contributor_data( $post ) {
+		$contributors = array();
+
+		$authors = get_post_authors_data( $post->ID );
+
+		if ( ! empty( $authors ) ) {
+			foreach ( $authors as $author ) {
+				$author_data = array(
+					'role' => 'author',
+					'name' => $author['display_name'],
+				);
+
+				$contributors[] = $author_data;
+			}
+		}
+
+		$secondary_bylines = get_post_meta( $post->ID, 'secondary_bylines', true );
+		if ( ! empty( $secondary_bylines ) ) {
+			foreach ( $secondary_bylines as $byline ) {
+				if ( empty( $byline['role'] ) || ( empty( $byline['custom_name'] ) && empty( $byline['id'] ) ) ) {
+					continue;
+				}
+
+				$secondary_contributor = array( 'role' => $byline['role'] );
+
+				if ( ! empty( $byline['id'] ) ) {
+					$user = get_user_by( 'id', $byline['id'] );
+					if ( $user instanceof \WP_User ) {
+						$secondary_contributor['name'] = $user->display_name;
+					} else if ( function_exists( 'get_coauthors' ) ) {
+						$name = (string) get_post_meta( $byline['id'], 'cap-display_name', true );
+						if ( empty( $name ) ) {
+							continue;
+						}
+						$secondary_contributor['name'] = $name;
+					} else {
+						continue;
+					}
+				} else {
+					$secondary_contributor['name'] = $byline['custom_name'];
+				}
+
+				$contributors[] = $secondary_contributor;
+			}
+		}
+
+		return $contributors;
+	}
+}
+
+Post_VC_Gen::instance();

--- a/classes/class-post-vc-gen.php
+++ b/classes/class-post-vc-gen.php
@@ -88,7 +88,7 @@ class Post_VC_Gen {
 			$jwt = $this->remote_sign_vc( $vc_data );
 			$vc_log .= "\nJWT: $jwt\n\n";
 		} catch ( \Exception $e ) {
-			$vc_log .= "\nfailed: " . $e->getMessage() . "\n\n";
+			$vc_log .= "\nFAILED: " . $e->getMessage() . "\n\n";
 		}
 
 		update_option( VC_LOG_OPTION_KEY, $vc_log );
@@ -161,7 +161,7 @@ class Post_VC_Gen {
 			'headers' => 'Content-Type: application/json',
 			'body' => json_encode( $data ),
 		);
-		$res = wp_remote_post( DID_AGENT_BASE_URL . '/sign-vc', $args );
+		$res = wp_remote_post( get_option( DID_AGENT_BASE_URL_OPTION_KEY, DID_AGENT_BASE_URL_DEFAULT ) . '/sign-vc', $args );
 
 		if ( is_wp_error( $res ) ) {
 			throw new \Exception( 'error making sign VC request: ' . json_encode( $res ) );

--- a/classes/class-post-vc-gen.php
+++ b/classes/class-post-vc-gen.php
@@ -178,4 +178,6 @@ class Post_VC_Gen {
 	}
 }
 
-Post_VC_Gen::instance();
+if ( get_option( DID_IS_ENABLED_OPTION_KEY ) ) {
+	Post_VC_Gen::instance();
+}

--- a/classes/class-post-vc-pub.php
+++ b/classes/class-post-vc-pub.php
@@ -211,9 +211,9 @@ class Post_VC_Pub {
 			$screen = get_current_screen();
 			$is_new_post = 'add' === $screen->action;
 			if ( $is_new_post ) { // a new post as opposed to editing an existing post.
-				$pub_vc = get_option( PUB_VC_BY_DEFAULT_ON_NEW_OPTION_KEY, PUB_VC_BY_DEFAULT_ON_NEW_DEFAULT );
+				$pub_vc = boolval( get_option( PUB_VC_BY_DEFAULT_ON_NEW_OPTION_KEY, PUB_VC_BY_DEFAULT_ON_NEW_DEFAULT ) );
 			} else {
-				$pub_vc = get_option( PUB_VC_BY_DEFAULT_ON_UPDATE_OPTION_KEY, PUB_VC_BY_DEFAULT_ON_UPDATE_DEFAULT );
+				$pub_vc = boolval( get_option( PUB_VC_BY_DEFAULT_ON_UPDATE_OPTION_KEY, PUB_VC_BY_DEFAULT_ON_UPDATE_DEFAULT ) );
 			}
 		}
 

--- a/classes/class-post-vc-pub.php
+++ b/classes/class-post-vc-pub.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Hanldes all logic related to generating and publishing VCs for posts.
+ * Handles all logic related to generating and publishing VCs for posts.
  *
  * @package Civil_Publisher
  */
@@ -28,6 +28,11 @@ class Post_VC_Pub {
 	 * @return bool Whether or not to publish a VC.
 	 */
 	public function should_pub_vc( $post_id ) : bool {
+		// Not initialized yet.
+		if ( ! get_option( ASSIGNED_DID_OPTION_KEY ) ) {
+			return false;
+		}
+
 		$should_gen = true;
 
 		// Only publish VCs for supported post types.
@@ -217,24 +222,29 @@ class Post_VC_Pub {
 			}
 		}
 
-		wp_nonce_field( 'civil_pub_vc_action', 'civil_pub_vc_nonce' );
-		?>
-		<label>
-			<input type="checkbox"
-				id="<?php echo esc_attr( PUB_VC_POST_KEY ); ?>"
-				name="<?php echo esc_attr( PUB_VC_POST_KEY ); ?>"
-				value="1"
-				<?php checked( $pub_vc, '1' ); ?>
-			/>
-			<?php
-			if ( $is_new_post ) {
-				_e( 'Publish VC', 'civil' );
-			} else {
-				// @TODO/tobek Once we're storing info about published VC, check it, and if none, change to "Publish"
-				_e( 'Update VC', 'civil' );
-			}
+		if ( ! get_option( ASSIGNED_DID_OPTION_KEY ) ) {
+			_e( 'Cannot publish VC: DID not initialized' );
+		} else {
+			wp_nonce_field( 'civil_pub_vc_action', 'civil_pub_vc_nonce' );
 			?>
-		</label>
+			<label>
+				<input type="checkbox"
+					id="<?php echo esc_attr( PUB_VC_POST_KEY ); ?>"
+					name="<?php echo esc_attr( PUB_VC_POST_KEY ); ?>"
+					value="true"
+					<?php checked( $pub_vc, true ); ?>
+				/>
+				<?php
+				if ( $is_new_post ) {
+					_e( 'Publish VC', 'civil' );
+				} else {
+					// @TODO/tobek Once we're storing info about published VC, check it, and if none, change to "Publish"
+					_e( 'Update VC', 'civil' );
+				}
+				?>
+			</label>
+		<?php } ?>
+
 		<p><br /><a href="<?php echo esc_url( menu_page_url( DID_SETTINGS_PAGE, false ) ); ?>" target="_blank">Edit settings</a></p>
 		<?php
 	}

--- a/classes/class-post-vc-pub.php
+++ b/classes/class-post-vc-pub.php
@@ -144,10 +144,10 @@ class Post_VC_Pub {
 	}
 
 	/**
-	 * Get contributor (authors, editors, others in the future) data for given post
+	 * Get contributor names for given post. Supports Coauthors Plus plugin.
 	 *
 	 * @param object $post A WP_Post object.
-	 * @return array List of data for each contributor on post.
+	 * @return array List of display names for each contributor on post.
 	 */
 	public function get_contributor_data( $post ) {
 		$contributors = array();
@@ -156,42 +156,7 @@ class Post_VC_Pub {
 
 		if ( ! empty( $authors ) ) {
 			foreach ( $authors as $author ) {
-				$author_data = array(
-					'role' => 'author',
-					'name' => $author['display_name'],
-				);
-
-				$contributors[] = $author_data;
-			}
-		}
-
-		$secondary_bylines = get_post_meta( $post->ID, 'secondary_bylines', true );
-		if ( ! empty( $secondary_bylines ) ) {
-			foreach ( $secondary_bylines as $byline ) {
-				if ( empty( $byline['role'] ) || ( empty( $byline['custom_name'] ) && empty( $byline['id'] ) ) ) {
-					continue;
-				}
-
-				$secondary_contributor = array( 'role' => $byline['role'] );
-
-				if ( ! empty( $byline['id'] ) ) {
-					$user = get_user_by( 'id', $byline['id'] );
-					if ( $user instanceof \WP_User ) {
-						$secondary_contributor['name'] = $user->display_name;
-					} else if ( function_exists( 'get_coauthors' ) ) {
-						$name = (string) get_post_meta( $byline['id'], 'cap-display_name', true );
-						if ( empty( $name ) ) {
-							continue;
-						}
-						$secondary_contributor['name'] = $name;
-					} else {
-						continue;
-					}
-				} else {
-					$secondary_contributor['name'] = $byline['custom_name'];
-				}
-
-				$contributors[] = $secondary_contributor;
+				$contributors[] = $author['display_name'];
 			}
 		}
 

--- a/classes/class-rest-api.php
+++ b/classes/class-rest-api.php
@@ -114,7 +114,7 @@ class REST_API {
 		if ( ! Post_Hashing::instance()->can_save_hash( $revision->post_parent ) ) {
 			return new \WP_Error(
 				'post-not-published',
-				esc_html__( 'This post revision is not publiushed.' ),
+				esc_html__( 'This post revision is not published.' ),
 				array(
 					'status' => 400,
 				)

--- a/classes/class-rest-api.php
+++ b/classes/class-rest-api.php
@@ -196,7 +196,7 @@ class REST_API {
 			);
 		}
 
-		// Get a the post with the hash.
+		// Get the post with the hash.
 		$posts = new \WP_Query(
 			array(
 				'post_type'        => array( 'revision' ),

--- a/did-doc.php
+++ b/did-doc.php
@@ -18,7 +18,7 @@ echo json_encode(
 				'id' => "did:web:$domain#owner",
 				'type' => 'RsaVerificationKey2018',
 				'owner' => "did:web:$domain",
-				'publicKeyPem' => "@TODO",
+				'publicKeyPem' => '@TODO',
 			),
 		),
 		'authentication' => array(

--- a/did-doc.php
+++ b/did-doc.php
@@ -18,7 +18,7 @@ echo json_encode(
 				'id' => "did:web:$domain#owner",
 				'type' => 'RsaVerificationKey2018',
 				'owner' => "did:web:$domain",
-				'publicKeyPem' => get_option( OPTION_DID_RSA_PUBLIC_KEY ),
+				'publicKeyPem' => "@TODO",
 			),
 		),
 		'authentication' => array(

--- a/did-doc.php
+++ b/did-doc.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Output DID document.
+ *
+ * @package Civil_Publisher
+ */
+
+namespace Civil_Publisher;
+
+$domain = preg_replace( '/^https?:\/\//', '', get_option( 'siteurl' ) );
+
+echo json_encode(
+	array(
+		'@context' => 'https://w3id.org/did/v1',
+		'id' => "did:web:$domain",
+		'publicKey' => array(
+			array(
+				'id' => "did:web:$domain#owner",
+				'type' => 'Secp256k1VerificationKey2018',
+				'owner' => "did:web:$domain",
+				'publicKeyHex' => '@TODO/tobek get actual pub key',
+			),
+		),
+		'authentication' => array(
+			array(
+				'type' => 'Secp256k1SignatureAuthentication2018',
+				'publicKey' => "did:web:$domain#owner",
+			),
+		),
+	)
+);

--- a/did-doc.php
+++ b/did-doc.php
@@ -16,14 +16,14 @@ echo json_encode(
 		'publicKey' => array(
 			array(
 				'id' => "did:web:$domain#owner",
-				'type' => 'Secp256k1VerificationKey2018',
+				'type' => 'RsaVerificationKey2018',
 				'owner' => "did:web:$domain",
-				'publicKeyHex' => '@TODO/tobek get actual pub key',
+				'publicKeyPem' => get_option( DID_RSA_PUBLIC_KEY ),
 			),
 		),
 		'authentication' => array(
 			array(
-				'type' => 'Secp256k1SignatureAuthentication2018',
+				'type' => 'RsaSignatureAuthentication2018',
 				'publicKey' => "did:web:$domain#owner",
 			),
 		),

--- a/did-doc.php
+++ b/did-doc.php
@@ -18,7 +18,7 @@ echo json_encode(
 				'id' => "did:web:$domain#owner",
 				'type' => 'RsaVerificationKey2018',
 				'owner' => "did:web:$domain",
-				'publicKeyPem' => get_option( DID_RSA_PUBLIC_KEY ),
+				'publicKeyPem' => get_option( OPTION_DID_RSA_PUBLIC_KEY ),
 			),
 		),
 		'authentication' => array(

--- a/did-settings.php
+++ b/did-settings.php
@@ -9,6 +9,15 @@ namespace Civil_Publisher;
 
 $did_doc_url = site_url( '/.well-known/did.json' );
 
+if ( current_user_can( 'manage_options' ) && isset( $_GET['clear-vc-log'] ) ) {
+	update_option( VC_LOG_OPTION_KEY, '' );
+	?>
+		<p>VC log cleared.</p>
+		<p><a href="<?php echo esc_url( menu_page_url( DID_SETTINGS_PAGE, false ) ); ?>">&laquo; Return to settings</a></p>
+	<?php
+	exit;
+}
+
 ?>
 
 <div class="wrap">
@@ -41,7 +50,10 @@ $did_doc_url = site_url( '/.well-known/did.json' );
 				<tr>
 					<th scope="row">VC log</th>
 					<td>
-						<pre style="max-width: 600px; overflow-x: auto; margin: 0; padding: 5px; background: #FBFBFB;"><?php echo esc_html( get_option( VC_LOG_OPTION_KEY ) ); ?></pre>
+						<pre style="max-width: 800px; overflow-x: auto; margin: 0; padding: 5px; background: #FBFBFB;"><?php echo esc_html( get_option( VC_LOG_OPTION_KEY ) ); ?></pre>
+						<?php if ( get_option( VC_LOG_OPTION_KEY ) ) { ?>
+							<p><a href="<?php echo esc_url( menu_page_url( DID_SETTINGS_PAGE, false ) . '&clear-vc-log' ); ?>"><button>Clear log</button></a></p>
+						<?php } ?>
 					</td>
 				</tr>
 				<?php if ( get_option( DID_ERROR_OPTION_KEY ) ) { ?>

--- a/did-settings.php
+++ b/did-settings.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * DID settings page.
+ *
+ * @package Civil_Publisher
+ */
+
+namespace Civil_Publisher;
+
+$did_doc_url = site_url( '/.well-known/did.json' );
+
+?>
+
+<div class="wrap">
+	<h1><?php esc_html_e( 'Decentralized Identity Tools', 'civil' ); ?></h1>
+	<p>@TODO copy TBD</p>
+	<p>Please contact <a href="mailto:support@civil.co">support@civil.co</a> with any questions or issues.</p>
+
+	<?php if ( current_user_can( 'manage_options' ) ) { ?>
+		<form action="options.php" method="post">
+			<?php
+				settings_fields( 'civil_did' );
+				do_settings_sections( 'did' );
+				submit_button( __( 'Save', 'civil' ) );
+			?>
+		</form>
+
+		<h2><em><?php esc_html_e( 'Debug Info', 'civil' ); ?></em></h2>
+		<table class="form-table">
+			<tbody>
+				<tr>
+					<th scope="row">DID doc</th>
+					<td><a href="<?php echo esc_url( $did_doc_url ); ?>" target="_blank"><?php echo esc_url( $did_doc_url ); ?></a></td>
+				</tr>
+				<tr>
+					<th scope="row">DID RSA public key</th>
+					<td>
+						<pre style="max-width: 600px; white-space: pre-wrap; margin: 0;"><?php echo esc_html( get_option( OPTION_DID_RSA_PUBLIC_KEY, '[not set]' ) ); ?></pre>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+	<?php } else { ?>
+		<h2><?php esc_html_e( 'Settings', 'civil' ); ?></h2>
+		<p><i><?php esc_html_e( 'You must be an admin in order to edit these settings.', 'civil' ); ?></i></p>
+	<?php } ?>
+</div>

--- a/did-settings.php
+++ b/did-settings.php
@@ -41,14 +41,14 @@ $did_doc_url = site_url( '/.well-known/did.json' );
 				<tr>
 					<th scope="row">VC log</th>
 					<td>
-						<pre style="max-width: 600px; white-space: pre-wrap; margin: 0;"><?php echo esc_html( get_option( VC_LOG_OPTION_KEY ) ); ?></pre>
+						<pre style="max-width: 600px; overflow-x: auto; margin: 0; padding: 5px; background: #FBFBFB;"><?php echo esc_html( get_option( VC_LOG_OPTION_KEY ) ); ?></pre>
 					</td>
 				</tr>
 				<?php if ( get_option( DID_ERROR_OPTION_KEY ) ) { ?>
 					<tr>
 						<th scope="row">error</th>
 						<td>
-							<pre style="max-width: 600px; white-space: pre-wrap; margin: 0;"><?php echo esc_html( get_option( DID_ERROR_OPTION_KEY ) ); ?></pre>
+							<pre style="max-width: 600px; white-space: pre-wrap; margin: 0; padding: 5px; background: #FBFBFB;"><?php echo esc_html( get_option( DID_ERROR_OPTION_KEY ) ); ?></pre>
 						</td>
 					</tr>
 				<?php } ?>

--- a/did-settings.php
+++ b/did-settings.php
@@ -38,6 +38,12 @@ $did_doc_url = site_url( '/.well-known/did.json' );
 					<th scope="row">DID doc</th>
 					<td><a href="<?php echo esc_url( $did_doc_url ); ?>" target="_blank"><?php echo esc_url( $did_doc_url ); ?></a></td>
 				</tr>
+				<tr>
+					<th scope="row">VC log</th>
+					<td>
+						<pre style="max-width: 600px; white-space: pre-wrap; margin: 0;"><?php echo esc_html( get_option( VC_LOG_OPTION_KEY ) ); ?></pre>
+					</td>
+				</tr>
 				<?php if ( get_option( DID_ERROR_OPTION_KEY ) ) { ?>
 					<tr>
 						<th scope="row">error</th>

--- a/did-settings.php
+++ b/did-settings.php
@@ -32,12 +32,6 @@ $did_doc_url = site_url( '/.well-known/did.json' );
 					<th scope="row">DID doc</th>
 					<td><a href="<?php echo esc_url( $did_doc_url ); ?>" target="_blank"><?php echo esc_url( $did_doc_url ); ?></a></td>
 				</tr>
-				<tr>
-					<th scope="row">DID RSA public key</th>
-					<td>
-						<pre style="max-width: 600px; white-space: pre-wrap; margin: 0;"><?php echo esc_html( get_option( OPTION_DID_RSA_PUBLIC_KEY, '[not set]' ) ); ?></pre>
-					</td>
-				</tr>
 			</tbody>
 		</table>
 	<?php } else { ?>

--- a/did-settings.php
+++ b/did-settings.php
@@ -7,16 +7,24 @@
 
 namespace Civil_Publisher;
 
-$did_doc_url = site_url( '/.well-known/did.json' );
-
 if ( current_user_can( 'manage_options' ) && isset( $_GET['clear-vc-log'] ) ) {
-	update_option( VC_LOG_OPTION_KEY, '' );
+	delete_option( VC_LOG_OPTION_KEY );
 	?>
 		<p>VC log cleared.</p>
 		<p><a href="<?php echo esc_url( menu_page_url( DID_SETTINGS_PAGE, false ) ); ?>">&laquo; Return to settings</a></p>
 	<?php
 	exit;
+} else if ( current_user_can( 'manage_options' ) && isset( $_GET['reset-did'] ) ) {
+	delete_option( ASSIGNED_DID_OPTION_KEY );
+	?>
+		<p>DID reset.</p>
+		<p>DID initialization process will be run on next admin page load.</p>
+		<p><a href="<?php echo esc_url( menu_page_url( DID_SETTINGS_PAGE, false ) ); ?>">&laquo; Return to settings</a></p>
+	<?php
+	exit;
 }
+
+$did_doc_url = site_url( '/.well-known/did.json' );
 
 ?>
 
@@ -34,13 +42,17 @@ if ( current_user_can( 'manage_options' ) && isset( $_GET['clear-vc-log'] ) ) {
 			?>
 		</form>
 
-		<h2><em><?php esc_html_e( 'Debug Info', 'civil' ); ?></em></h2>
+		<h2><em><?php esc_html_e( 'Debug', 'civil' ); ?></em></h2>
 		<table class="form-table">
 			<tbody>
 				<tr>
 					<th scope="row">TrustAgent DID</th>
 					<td>
 						<pre style="max-width: 600px; white-space: pre-wrap; margin: 0;"><?php echo esc_html( get_option( ASSIGNED_DID_OPTION_KEY, '[not set]' ) ); ?></pre>
+						<?php if ( get_option( ASSIGNED_DID_OPTION_KEY ) ) { ?>
+							<p><a href="<?php echo esc_url( menu_page_url( DID_SETTINGS_PAGE, false ) . '&reset-did' ); ?>"><button>Reset DID</button></a></p>
+							<p>(Note that the DID initialization process will be run on next admin page load.)</p>
+						<?php } ?>
 					</td>
 				</tr>
 				<tr>

--- a/did-settings.php
+++ b/did-settings.php
@@ -31,18 +31,18 @@ $did_doc_url = site_url( '/.well-known/did.json' );
 				<tr>
 					<th scope="row">TrustAgent DID</th>
 					<td>
-						<pre style="max-width: 600px; white-space: pre-wrap; margin: 0;"><?php echo esc_html( get_option( OPTION_ASSIGNED_DID, '[not set]' ) ); ?></pre>
+						<pre style="max-width: 600px; white-space: pre-wrap; margin: 0;"><?php echo esc_html( get_option( ASSIGNED_DID_OPTION_KEY, '[not set]' ) ); ?></pre>
 					</td>
 				</tr>
 				<tr>
 					<th scope="row">DID doc</th>
 					<td><a href="<?php echo esc_url( $did_doc_url ); ?>" target="_blank"><?php echo esc_url( $did_doc_url ); ?></a></td>
 				</tr>
-				<?php if ( get_option( OPTION_DID_ERROR ) ) { ?>
+				<?php if ( get_option( DID_ERROR_OPTION_KEY ) ) { ?>
 					<tr>
 						<th scope="row">error</th>
 						<td>
-							<pre style="max-width: 600px; white-space: pre-wrap; margin: 0;"><?php echo esc_html( get_option( OPTION_DID_ERROR ) ); ?></pre>
+							<pre style="max-width: 600px; white-space: pre-wrap; margin: 0;"><?php echo esc_html( get_option( DID_ERROR_OPTION_KEY ) ); ?></pre>
 						</td>
 					</tr>
 				<?php } ?>

--- a/did-settings.php
+++ b/did-settings.php
@@ -29,9 +29,23 @@ $did_doc_url = site_url( '/.well-known/did.json' );
 		<table class="form-table">
 			<tbody>
 				<tr>
+					<th scope="row">TrustAgent DID</th>
+					<td>
+						<pre style="max-width: 600px; white-space: pre-wrap; margin: 0;"><?php echo esc_html( get_option( OPTION_ASSIGNED_DID, '[not set]' ) ); ?></pre>
+					</td>
+				</tr>
+				<tr>
 					<th scope="row">DID doc</th>
 					<td><a href="<?php echo esc_url( $did_doc_url ); ?>" target="_blank"><?php echo esc_url( $did_doc_url ); ?></a></td>
 				</tr>
+				<?php if ( get_option( OPTION_DID_ERROR ) ) { ?>
+					<tr>
+						<th scope="row">error</th>
+						<td>
+							<pre style="max-width: 600px; white-space: pre-wrap; margin: 0;"><?php echo esc_html( get_option( OPTION_DID_ERROR ) ); ?></pre>
+						</td>
+					</tr>
+				<?php } ?>
 			</tbody>
 		</table>
 	<?php } else { ?>

--- a/did-vc.php
+++ b/did-vc.php
@@ -90,30 +90,76 @@ register_activation_hook( PLUGIN_FILE, __NAMESPACE__ . '\flush_rules' );
 function add_did_settings() {
 	add_settings_section( 'civil_did', __( 'Settings', 'civil' ), null, 'did' );
 
-	add_settings_field( DID_IS_ENABLED_OPTION_KEY, __( 'Enable DID features', 'civil' ), __NAMESPACE__ . '\display_did_is_enabled_input', 'did', 'civil_did' );
+	add_settings_field(
+		DID_IS_ENABLED_OPTION_KEY,
+		__( 'Enable DID features', 'civil' ),
+		__NAMESPACE__ . '\display_boolean_setting_input',
+		'did',
+		'civil_did',
+		array(
+			'option_key' => DID_IS_ENABLED_OPTION_KEY,
+			'default' => DID_IS_ENABLED_DEFAULT,
+		)
+	);
+	add_settings_field(
+		PUB_VC_BY_DEFAULT_ON_NEW_OPTION_KEY,
+		__( 'Publish VC by default on new posts', 'civil' ),
+		__NAMESPACE__ . '\display_boolean_setting_input',
+		'did',
+		'civil_did',
+		array(
+			'option_key' => PUB_VC_BY_DEFAULT_ON_NEW_OPTION_KEY,
+			'default' => PUB_VC_BY_DEFAULT_ON_NEW_DEFAULT,
+			'description' => 'This can be overriden on a per-post basis.',
+		)
+	);
+	add_settings_field(
+		PUB_VC_BY_DEFAULT_ON_UPDATE_OPTION_KEY,
+		__( 'Publish updates to VC by default when updating existing posts', 'civil' ),
+		__NAMESPACE__ . '\display_boolean_setting_input',
+		'did',
+		'civil_did',
+		array(
+			'option_key' => PUB_VC_BY_DEFAULT_ON_UPDATE_OPTION_KEY,
+			'default' => PUB_VC_BY_DEFAULT_ON_UPDATE_DEFAULT,
+			'description' => 'This can be overriden on a per-post basis.',
+		)
+	);
+	add_settings_field(
+		DID_AGENT_BASE_URL_OPTION_KEY,
+		__( 'DID agent URL', 'civil' ),
+		__NAMESPACE__ . '\display_did_agent_url',
+		'did',
+		'civil_did'
+	);
+
 	register_setting( 'civil_did', DID_IS_ENABLED_OPTION_KEY );
-	add_settings_field( DID_AGENT_BASE_URL_OPTION_KEY, __( 'DID agent URL', 'civil' ), __NAMESPACE__ . '\display_did_agent_url', 'did', 'civil_did' );
+	register_setting( 'civil_did', PUB_VC_BY_DEFAULT_ON_NEW_OPTION_KEY );
+	register_setting( 'civil_did', PUB_VC_BY_DEFAULT_ON_UPDATE_OPTION_KEY );
 	register_setting( 'civil_did', DID_AGENT_BASE_URL_OPTION_KEY );
 }
 add_action( 'admin_init', __NAMESPACE__ . '\add_did_settings' );
 
 /**
- * Output the DID enabled input.
+ * Output checkbox input for boolean settings.
+ *
+ * @param array $args Arguments sent by add_settings_field(): option_key, default, description (optional).
  */
-function display_did_is_enabled_input() {
-	$enable = boolval( get_option( DID_IS_ENABLED_OPTION_KEY, DID_IS_ENABLED_DEFAULT ) );
+function display_boolean_setting_input( $args ) {
+	$enable = boolval( get_option( $args['option_key'], $args['default'] ) );
 	?>
 		<div style="max-width: 600px">
 			<label>
 				<input
 					type="checkbox"
-					name="<?php echo esc_attr( DID_IS_ENABLED_OPTION_KEY ); ?>"
-					id="<?php echo esc_attr( DID_IS_ENABLED_OPTION_KEY ); ?>"
+					name="<?php echo esc_attr( $args['option_key'] ); ?>"
+					id="<?php echo esc_attr( $args['option_key'] ); ?>"
 					<?php checked( $enable, true ); ?>
 				/>
-				<?php _e( 'Enable DID features' ); ?>
 			</label>
-			<!-- <p><?php _e( '@TODO copy with more details TBD' ); ?></p> -->
+			<?php if ( isset( $args['description'] ) ) { ?>
+				<p><?php esc_html_e( $args['description'] ); ?></p>
+			<?php } ?>
 		</div>
 	<?php
 }

--- a/did-vc.php
+++ b/did-vc.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Handles DID and VC logic for ID Hub integration.
+ *
+ * @package Civil_Publisher
+ */
+
+namespace Civil_Publisher;
+
+/**
+ * Init DID logic.
+ */
+function init() {
+	add_filter( 'template_include', __NAMESPACE__ . '\include_template' );
+	add_filter( 'init', __NAMESPACE__ . '\rewrite_rules' );
+}
+
+/**
+ * Override template file for DID doc.
+ *
+ * @param string $template Path of template.
+ */
+function include_template( $template ) {
+	if ( get_query_var( 'civil_publisher_did' ) ) {
+		return PATH . '/did-doc.php';
+	}
+
+	return $template;
+}
+
+/**
+ * Flush rewrite rules.
+ */
+function flush_rules() {
+	$this->rewrite_rules();
+	flush_rewrite_rules();
+}
+
+/**
+ * Set up rewrite rules for DID doc.
+ */
+function rewrite_rules() {
+	add_rewrite_rule( '^\.well-known/did\.json$', 'index.php?civil_publisher_did=true', 'top' );
+	add_rewrite_tag( '%civil_publisher_did%', '*' );
+}
+
+add_action( 'plugins_loaded', __NAMESPACE__ . '\init' );
+
+// On plugin activation flush rewrite rules.
+register_activation_hook( PLUGIN_FILE, __NAMESPACE__ . '\flush_rules' );
+

--- a/did-vc.php
+++ b/did-vc.php
@@ -13,6 +13,43 @@ namespace Civil_Publisher;
 function init() {
 	add_filter( 'template_include', __NAMESPACE__ . '\include_template' );
 	add_filter( 'init', __NAMESPACE__ . '\rewrite_rules' );
+
+	if ( current_user_can( 'manage_options' ) && empty( get_option( DID_RSA_PRIVATE_KEY ) ) ) {
+		try {
+			init_key_pair();
+		} catch ( Exception $e ) {
+			// @TODO/tobek Surface this error in admin. If missing openssl configs are a problem in the wild, consider using phpseclib instead.
+			update_option( DID_RSA_KEY_ERROR, 'Failed to generate openssl key pair: ' . $e->getMessage() );
+		}
+	}
+}
+
+/**
+ * Init DID key pair and save in database.
+ *
+ * Note that we store the DID private key in plain text in the database. This is of course awfully insecure, but if we want to be able to publish VCs without user interaction then the plugin needs access to the private key somehow. We could do various things to superficially harden the key but they are all either too brittle (e.g. using user's login password as encryption key would break if user loses password and resets it, while using wp-config.php salts as encryption key would break if user migrates to a new WP install) or trivial to defeat (storing encryption key in plugin to encrypt value stored in DB sounds nice, but anyone with access to the DB could trivially google the option name and find this open source plugin and decrypt from there). Even something fancy that required user-held secrets and user interaction for every action (e.g. signing in metamask) could be vulnerable to spoofed requests if the site is compromised. Fundamentally this private key does not protect anything special at the moment; it's more of an identifier. This can be revisited in the future.
+ */
+function init_key_pair() {
+	$key = openssl_pkey_new(
+		array(
+			'digest_alg' => 'sha512',
+			'private_key_bits' => 4096,
+			'private_key_type' => OPENSSL_KEYTYPE_RSA,
+		)
+	);
+
+	openssl_pkey_export( $key, $private_key );
+
+	$public_key = openssl_pkey_get_details( $key );
+	$public_key = $public_key['key'];
+
+	if ( $private_key && $public_key ) {
+		delete_option( DID_RSA_KEY_ERROR );
+		update_option( DID_RSA_PRIVATE_KEY, $private_key );
+		update_option( DID_RSA_PUBLIC_KEY, $public_key );
+	} else {
+		update_option( DID_RSA_KEY_ERROR, 'Failed to generate openssl key pair: generated keys are falsey.' );
+	}
 }
 
 /**

--- a/did-vc.php
+++ b/did-vc.php
@@ -11,19 +11,19 @@ namespace Civil_Publisher;
  * Init DID logic.
  */
 function init() {
-	if ( ! get_option( OPTION_DID_IS_ENABLED ) ) {
+	if ( ! get_option( DID_IS_ENABLED_OPTION_KEY ) ) {
 		return;
 	}
 
 	add_filter( 'template_include', __NAMESPACE__ . '\include_template' );
 	add_filter( 'init', __NAMESPACE__ . '\rewrite_rules' );
 
-	if ( current_user_can( 'manage_options' ) && empty( get_option( OPTION_ASSIGNED_DID ) ) ) {
+	if ( current_user_can( 'manage_options' ) && empty( get_option( ASSIGNED_DID_OPTION_KEY ) ) ) {
 		try {
 			init_did();
 		} catch ( Exception $e ) {
 			// @TODO/tobek Surface these errors as WP notice
-			update_option( OPTION_DID_ERROR, 'Failed to generate openssl key pair: ' . $e->getMessage() );
+			update_option( DID_ERROR_OPTION_KEY, 'Failed to generate openssl key pair: ' . $e->getMessage() );
 		}
 	}
 }
@@ -34,19 +34,19 @@ function init() {
 function init_did() {
 	$res = wp_remote_get( DID_AGENT_BASE_URL . '/init' );
 	if ( is_wp_error( $res ) ) {
-		update_option( OPTION_DID_ERROR, 'error making DID init request: ' . json_encode( $res ) );
+		update_option( DID_ERROR_OPTION_KEY, 'error making DID init request: ' . json_encode( $res ) );
 		return;
 	} else if ( 200 != $res['response']['code'] ) {
-		update_option( OPTION_DID_ERROR, 'error response from DID init request: ' . $res['response']['code'] . ': ' . $res['response']['message'] );
+		update_option( DID_ERROR_OPTION_KEY, 'error response from DID init request: ' . $res['response']['code'] . ': ' . $res['response']['message'] );
 		return;
 	}
 
 	$body = json_decode( $res['body'] );
 	if ( $body && $body->issuer ) {
-		update_option( OPTION_ASSIGNED_DID, $body->issuer );
-		delete_option( OPTION_DID_ERROR );
+		update_option( ASSIGNED_DID_OPTION_KEY, $body->issuer );
+		delete_option( DID_ERROR_OPTION_KEY );
 	} else {
-		update_option( OPTION_DID_ERROR, 'invalid response body from DID init request: ' . $res['body'] );
+		update_option( DID_ERROR_OPTION_KEY, 'invalid response body from DID init request: ' . $res['body'] );
 	}
 }
 
@@ -90,8 +90,8 @@ register_activation_hook( PLUGIN_FILE, __NAMESPACE__ . '\flush_rules' );
 function add_did_settings() {
 	add_settings_section( 'civil_did', __( 'Settings', 'civil' ), null, 'did' );
 
-	add_settings_field( OPTION_DID_IS_ENABLED, __( 'Enable DID features', 'civil' ), __NAMESPACE__ . '\display_did_is_enabled_input', 'did', 'civil_did' );
-	register_setting( 'civil_did', OPTION_DID_IS_ENABLED );
+	add_settings_field( DID_IS_ENABLED_OPTION_KEY, __( 'Enable DID features', 'civil' ), __NAMESPACE__ . '\display_did_is_enabled_input', 'did', 'civil_did' );
+	register_setting( 'civil_did', DID_IS_ENABLED_OPTION_KEY );
 }
 add_action( 'admin_init', __NAMESPACE__ . '\add_did_settings' );
 
@@ -99,14 +99,14 @@ add_action( 'admin_init', __NAMESPACE__ . '\add_did_settings' );
  * Output the DID enabled input.
  */
 function display_did_is_enabled_input() {
-	$enable = boolval( get_option( OPTION_DID_IS_ENABLED, DID_IS_ENABLED_DEFAULT ) );
+	$enable = boolval( get_option( DID_IS_ENABLED_OPTION_KEY, DID_IS_ENABLED_DEFAULT ) );
 	?>
 		<div style="max-width: 600px">
 			<label>
 				<input
 					type="checkbox"
-					name="<?php echo esc_attr( OPTION_DID_IS_ENABLED ); ?>"
-					id="<?php echo esc_attr( OPTION_DID_IS_ENABLED ); ?>"
+					name="<?php echo esc_attr( DID_IS_ENABLED_OPTION_KEY ); ?>"
+					id="<?php echo esc_attr( DID_IS_ENABLED_OPTION_KEY ); ?>"
 					<?php checked( $enable, true ); ?>
 				/>
 				<?php _e( 'Enable DID features.' ); ?>

--- a/did-vc.php
+++ b/did-vc.php
@@ -57,7 +57,7 @@ function init_did() {
  */
 function include_template( $template ) {
 	if ( get_query_var( 'civil_publisher_did' ) ) {
-		return PATH . '/did-doc.php';
+		return dirname( PLUGIN_FILE ) . '/did-doc.php';
 	}
 
 	return $template;

--- a/did-vc.php
+++ b/did-vc.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Handles DID and VC logic for ID Hub integration.
+ * Handles DID and VC initialization, settings, and misc logic.
  *
  * @package Civil_Publisher
  */

--- a/did-vc.php
+++ b/did-vc.php
@@ -67,7 +67,7 @@ function include_template( $template ) {
  * Flush rewrite rules.
  */
 function flush_rules() {
-	$this->rewrite_rules();
+	rewrite_rules();
 	flush_rewrite_rules();
 }
 

--- a/did-vc.php
+++ b/did-vc.php
@@ -18,42 +18,21 @@ function init() {
 	add_filter( 'template_include', __NAMESPACE__ . '\include_template' );
 	add_filter( 'init', __NAMESPACE__ . '\rewrite_rules' );
 
-	if ( current_user_can( 'manage_options' ) && empty( get_option( OPTION_DID_RSA_PRIVATE_KEY ) ) ) {
+	if ( current_user_can( 'manage_options' ) ) {
 		try {
-			init_key_pair();
+			init_did();
 		} catch ( Exception $e ) {
-			// @TODO/tobek Surface this error in admin. If missing openssl configs are a problem in the wild, consider using phpseclib instead.
-			update_option( OPTION_DID_RSA_KEY_ERROR, 'Failed to generate openssl key pair: ' . $e->getMessage() );
+			// @TODO/tobek Surface this error in admin
+			update_option( OPTION_DID_ERROR, 'Failed to generate openssl key pair: ' . $e->getMessage() );
 		}
 	}
 }
 
 /**
- * Init DID key pair and save in database.
- *
- * Note that we store the DID private key in plain text in the database. This is of course awfully insecure, but if we want to be able to publish VCs without user interaction then the plugin needs access to the private key somehow. We could do various things to superficially harden the key but they are all either too brittle (e.g. using user's login password as encryption key would break if user loses password and resets it, while using wp-config.php salts as encryption key would break if user migrates to a new WP install) or trivial to defeat (storing encryption key in plugin to encrypt value stored in DB sounds nice, but anyone with access to the DB could trivially google the option name and find this open source plugin and decrypt from there). Even something fancy that required user-held secrets and user interaction for every action (e.g. signing in metamask) could be vulnerable to spoofed requests if the site is compromised. Fundamentally this private key does not protect anything special at the moment; it's more of an identifier. This can be revisited in the future.
+ * Init DID.
  */
-function init_key_pair() {
-	$key = openssl_pkey_new(
-		array(
-			'digest_alg' => 'sha512',
-			'private_key_bits' => 4096,
-			'private_key_type' => OPENSSL_KEYTYPE_RSA,
-		)
-	);
-
-	openssl_pkey_export( $key, $private_key );
-
-	$public_key = openssl_pkey_get_details( $key );
-	$public_key = $public_key['key'];
-
-	if ( $private_key && $public_key ) {
-		delete_option( OPTION_DID_RSA_KEY_ERROR );
-		update_option( OPTION_DID_RSA_PRIVATE_KEY, $private_key );
-		update_option( OPTION_DID_RSA_PUBLIC_KEY, $public_key );
-	} else {
-		update_option( OPTION_DID_RSA_KEY_ERROR, 'Failed to generate openssl key pair: generated keys are falsey.' );
-	}
+function init_did() {
+	// @TODO/tobek
 }
 
 /**

--- a/did-vc.php
+++ b/did-vc.php
@@ -21,9 +21,9 @@ function init() {
 	if ( current_user_can( 'manage_options' ) && empty( get_option( ASSIGNED_DID_OPTION_KEY ) ) ) {
 		try {
 			init_did();
-		} catch ( Exception $e ) {
+		} catch ( \Error $e ) {
 			// @TODO/tobek Surface these errors as WP notice
-			update_option( DID_ERROR_OPTION_KEY, 'Failed to generate openssl key pair: ' . $e->getMessage() );
+			update_option( DID_ERROR_OPTION_KEY, 'Failed to initialize DID: ' . $e->getMessage() );
 		}
 	}
 }
@@ -34,10 +34,10 @@ function init() {
 function init_did() {
 	$res = wp_remote_get( get_option( DID_AGENT_BASE_URL_OPTION_KEY, DID_AGENT_BASE_URL_DEFAULT ) . '/init' );
 	if ( is_wp_error( $res ) ) {
-		update_option( DID_ERROR_OPTION_KEY, 'error making DID init request: ' . json_encode( $res ) );
+		update_option( DID_ERROR_OPTION_KEY, 'Error making DID init request: ' . json_encode( $res ) );
 		return;
 	} else if ( 200 != $res['response']['code'] ) {
-		update_option( DID_ERROR_OPTION_KEY, 'error response from DID init request: ' . $res['response']['code'] . ': ' . $res['response']['message'] );
+		update_option( DID_ERROR_OPTION_KEY, 'Error response from DID init request: ' . $res['response']['code'] . ': ' . $res['response']['message'] );
 		return;
 	}
 
@@ -46,7 +46,7 @@ function init_did() {
 		update_option( ASSIGNED_DID_OPTION_KEY, $body->issuer );
 		delete_option( DID_ERROR_OPTION_KEY );
 	} else {
-		update_option( DID_ERROR_OPTION_KEY, 'invalid response body from DID init request: ' . $res['body'] );
+		update_option( DID_ERROR_OPTION_KEY, 'Invalid response body from DID init request: ' . $res['body'] );
 	}
 }
 

--- a/did-vc.php
+++ b/did-vc.php
@@ -32,7 +32,7 @@ function init() {
  * Init DID.
  */
 function init_did() {
-	$res = wp_remote_get( DID_AGENT_BASE_URL . '/init' );
+	$res = wp_remote_get( get_option( DID_AGENT_BASE_URL_OPTION_KEY, DID_AGENT_BASE_URL_DEFAULT ) . '/init' );
 	if ( is_wp_error( $res ) ) {
 		update_option( DID_ERROR_OPTION_KEY, 'error making DID init request: ' . json_encode( $res ) );
 		return;
@@ -92,6 +92,8 @@ function add_did_settings() {
 
 	add_settings_field( DID_IS_ENABLED_OPTION_KEY, __( 'Enable DID features', 'civil' ), __NAMESPACE__ . '\display_did_is_enabled_input', 'did', 'civil_did' );
 	register_setting( 'civil_did', DID_IS_ENABLED_OPTION_KEY );
+	add_settings_field( DID_AGENT_BASE_URL_OPTION_KEY, __( 'DID agent URL', 'civil' ), __NAMESPACE__ . '\display_did_agent_url', 'did', 'civil_did' );
+	register_setting( 'civil_did', DID_AGENT_BASE_URL_OPTION_KEY );
 }
 add_action( 'admin_init', __NAMESPACE__ . '\add_did_settings' );
 
@@ -109,9 +111,29 @@ function display_did_is_enabled_input() {
 					id="<?php echo esc_attr( DID_IS_ENABLED_OPTION_KEY ); ?>"
 					<?php checked( $enable, true ); ?>
 				/>
-				<?php _e( 'Enable DID features.' ); ?>
+				<?php _e( 'Enable DID features' ); ?>
 			</label>
-			<p><?php _e( '@TODO copy with more details TBD' ); ?></p>
+			<!-- <p><?php _e( '@TODO copy with more details TBD' ); ?></p> -->
+		</div>
+	<?php
+}
+
+/**
+ * Output the DID agent URL input.
+ */
+function display_did_agent_url() {
+	$url = strval( get_option( DID_AGENT_BASE_URL_OPTION_KEY, DID_AGENT_BASE_URL_DEFAULT ) );
+	?>
+		<div style="max-width: 600px">
+			<label>
+				<input
+					type="text"
+					style="width: 400px"
+					name="<?php echo esc_attr( DID_AGENT_BASE_URL_OPTION_KEY ); ?>"
+					id="<?php echo esc_attr( DID_AGENT_BASE_URL_OPTION_KEY ); ?>"
+					value="<?php echo esc_attr( $url ); ?>"
+				/>
+			</label>
 		</div>
 	<?php
 }

--- a/story-boosts-settings.php
+++ b/story-boosts-settings.php
@@ -4,6 +4,9 @@
  *
  * @package Civil_Publisher
  */
+
+namespace Civil_Publisher;
+
 ?>
 
 <div class="wrap">

--- a/story-boosts.php
+++ b/story-boosts.php
@@ -47,7 +47,7 @@ function story_boost_meta_box_callback( $post ) {
 		<?php _e( 'Enable Story Boost', 'civil' ); ?>
 	</label>
 	<p style="margin-top: 10px">Embed a small widget to the end of this post that allows readers to support your newsroom with direct payments. If enabled, this post will also be submitted to the <a href="https://registry.civil.co/storyfeed" target="_blank">Civil story feed &#129125;</a>.<!--  <a href="#@TODO/toby" target="_blank">More information</a>.--></p>
-	<p><a href="<?php echo esc_url( menu_page_url( STORY_BOOSTS_SETTINGS, false ) ); ?>" target="_blank">Edit settings</a></p>
+	<p><a href="<?php echo esc_url( menu_page_url( STORY_BOOSTS_SETTINGS_PAGE, false ) ); ?>" target="_blank">Edit settings</a></p>
 	<?php
 }
 
@@ -132,7 +132,7 @@ add_action( 'wp_head', __NAMESPACE__ . '\story_boost_timestamp_metadata' );
 /**
  * Add settings fields to control Story Boosts.
  */
-function add_settings() {
+function add_story_boost_settings() {
 	add_settings_section( 'civil_story_boosts', __( 'Settings', 'civil' ), null, 'story-boosts' );
 
 	add_settings_field( STORY_BOOSTS_ENABLE_BY_DEFAULT, __( 'Enable by Default', 'civil' ), __NAMESPACE__ . '\display_enable_by_default_input', 'story-boosts', 'civil_story_boosts' );
@@ -140,7 +140,7 @@ function add_settings() {
 	register_setting( 'civil_story_boosts', STORY_BOOSTS_ENABLE_BY_DEFAULT );
 	register_setting( 'civil_story_boosts', STORY_BOOSTS_PRIORITY );
 }
-add_action( 'admin_init', __NAMESPACE__ . '\add_settings' );
+add_action( 'admin_init', __NAMESPACE__ . '\add_story_boost_settings' );
 
 /**
  * Output the enable by default input.

--- a/utils.php
+++ b/utils.php
@@ -34,7 +34,7 @@ function get_civil_post_types() {
 /**
  * Checks if the currently-logged-in-user can sign posts with the plugin.
  *
- * @return bool Whether or not tthey can sign.
+ * @return bool Whether or not they can sign.
  */
 function current_user_can_sign_posts() {
 	// If user can't edit published posts, then they can't sign any updates to their posts, so rather than let them sign drafts and have invalid (and removed) signature on anly published updates, don't let them sign at all (until we have some way to add signatures outside of the edit post context).

--- a/utils.php
+++ b/utils.php
@@ -206,3 +206,32 @@ function generate_uuid_v4() {
 
 	return vsprintf( '%s%s-%s-%s-%s-%s%s%s', str_split( bin2hex( $data ), 4 ) );
 }
+
+/**
+ * Retrieves the timezone from site settings as a `DateTimeZone` object.
+ *
+ * @return DateTimeZone Timezone object.
+ */
+function get_site_timezone() {
+	if ( function_exists( 'wp_timezone' ) ) {
+		// WordPress v5.3.0 or later.
+		return wp_timezone();
+	}
+
+	// For older versions that don't have them, copy-pasting code from `wp_timezone` and `wp_timezone_string`.
+
+	$timezone_string = get_option( 'timezone_string' );
+
+	if ( ! $timezone_string ) {
+		$offset  = (float) get_option( 'gmt_offset' );
+		$hours   = (int) $offset;
+		$minutes = ( $offset - $hours );
+
+		$sign      = ( $offset < 0 ) ? '-' : '+';
+		$abs_hour  = abs( $hours );
+		$abs_mins  = abs( $minutes * 60 );
+		$timezone_string = sprintf( '%s%02d:%02d', $sign, $abs_hour, $abs_mins );
+	}
+
+	return new \DateTimeZone( $timezone_string );
+}


### PR DESCRIPTION
Integrates with remote KMS and VC-signer (currently a DAF instance, will in future be TrustAgent or Content Service proxying to TrustAgent) to generate DID and issue VCs for published content.

Note that I've continued to use "civil" namespacing and copy, in order to facilitate grepping for upcoming updates that will strip all the Civil stuff and move to a new repo.

Main features:

- Initializes DID and stores info about it
- Displays a stub DID doc `/.well-known/did.json`
- Ability to, on post publish and update, generate metadata blog and send to DAF instance to get signed VC JWT back, plus various associated features (e.g. indexing posts by a UUID)
- Various settings to control DID and VC behavior

![content-vc-plugin](https://user-images.githubusercontent.com/3081073/81033203-88f80800-8e47-11ea-9cbf-1e9b227d1c37.png)