### PR TITLE
Migrate to DAF server and expose get_vc_for_post_id function

### DIFF
--- a/classes/class-daf-service.php
+++ b/classes/class-daf-service.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Handles API requests to DAF server.
+ *
+ * @package ConsenSys_VC_Publisher
+ */
+
+namespace ConsenSys_VC_Publisher;
+
+/**
+ * The Daf_Service class.
+ */
+class Daf_Service {
+	use Singleton;
+
+	/**
+	 * Set up the class.
+	 */
+	public function setup() {
+	}
+
+	/**
+	 * Call identityManagerGetOrCreateIdentity endpoint.
+	 *
+	 * @param array $body Request body.
+	 * @throws \Exception Errors from API request.
+	 * @return array Response body.
+	 */
+	public function identity_manager_get_or_create_identity( $body ) {
+		return $this->request( '/identityManagerGetOrCreateIdentity', $body );
+	}
+
+	/**
+	 * Call createVerifiableCredential endpoint.
+	 *
+	 * @param array $body Request body.
+	 * @throws \Exception Errors from API request.
+	 * @return array Response body.
+	 */
+	public function create_verifiable_credential( $body ) {
+		return $this->request( '/createVerifiableCredential', $body );
+	}
+
+	/**
+	 * Call arbitrary endpoint.
+	 *
+	 * @param string $path Request path.
+	 * @param array  $body Request body.
+	 * @throws \Exception Errors from API request.
+	 * @return array Response body.
+	 */
+	public function request( $path, $body = null ) {
+		$args = null;
+		if ( $body ) {
+			$args = array(
+				'headers' => array(
+					'Content-Type' => 'application/json',
+				),
+				'body' => json_encode( $body ),
+			);
+		}
+
+		$url = get_option( DAF_BASE_URL_OPTION_KEY ) . $path;
+		$res = wp_remote_post( $url, $args );
+
+		if ( is_wp_error( $res ) ) {
+			$err = sprintf(
+				'Error making request to DAF at %s: %s',
+				$url,
+				json_encode( $res )
+			);
+			error_log( $err );
+			throw new \Exception( $err );
+		} else if ( $res['response']['code'] < 200 || $res['response']['code'] > 299 ) {
+			$err = sprintf(
+				'[%d] Error response from DAF at %s: %s',
+				$res['response']['code'],
+				$url,
+				$res['response']['message'] . ( isset( $res['body'] ) ? ( " ($res[body])" ) : '' )
+			);
+			error_log( $err );
+			throw new \Exception( $err );
+		}
+
+		return json_decode( $res['body'] );
+	}
+}
+
+if ( get_option( DID_IS_ENABLED_OPTION_KEY, DID_IS_ENABLED_DEFAULT ) ) {
+	Daf_Service::instance();
+}

--- a/classes/class-post-vc-pub.php
+++ b/classes/class-post-vc-pub.php
@@ -112,7 +112,7 @@ class Post_VC_Pub {
 			'issuer' => array(
 				'id' => get_option( ASSIGNED_DID_OPTION_KEY ),
 			),
-			'issuanceDate' => date( 'c' ),
+			'issuanceDate' => gmdate( 'c' ),
 			'credentialSubject' => $this->generate_vc_body( $post ),
 		);
 	}
@@ -158,7 +158,7 @@ class Post_VC_Pub {
 				'versionIdentifier' => $revision_uuid,
 				'headline'          => $post->post_title,
 				'description'       => $post->post_excerpt,
-				'url'               => get_permalink( $parent_post->ID ),
+				'url'               => get_permalink( $post->ID ),
 				'dateModified'      => $post->post_modified_gmt,
 				'datePublished'     => $post->post_date_gmt,
 				'publisher'         => $this->get_publisher_data(),

--- a/classes/class-post-vc-pub.php
+++ b/classes/class-post-vc-pub.php
@@ -83,10 +83,11 @@ class Post_VC_Pub {
 		$vc_log .= "generating VC for post $post->ID\nvc: " . json_encode( $vc, JSON_UNESCAPED_SLASHES );
 
 		try {
-			$jwt = $this->remote_issue_vc( $vc );
-			$vc_log .= "\nJWT: $jwt\n\n";
+			$vc_response = $this->remote_issue_vc( $vc );
+			$vc_json = json_encode( $vc_response, JSON_UNESCAPED_SLASHES );
+			$vc_log .= "\nresponse: $vc_json\n\n";
 			update_post_meta( $post_id, LAST_VC_PUB_DATE_META_KEY, $post->post_modified_gmt );
-			// @TODO/tobek Now actually do something with the VC or JWT
+			update_post_meta( $post_id, POST_VC_META_KEY, $vc_json );
 		} catch ( \Exception $e ) {
 			$vc_log .= "\nFAILED: " . $e->getMessage() . "\n\n";
 		}
@@ -215,38 +216,22 @@ class Post_VC_Pub {
 	 *
 	 * @param array $credential Associative array of VC data.
 	 * @throws \Exception Error messages from sign VC request.
-	 * @return string The encoded JWT.
+	 * @return string The issued VC.
 	 */
 	public function remote_issue_vc( $credential ) {
-		$post_body = array(
+		$body = array(
 			'credential' => $credential,
 			'revocable' => true,
 			'keepCopy' => true,
 			'save' => true,
 			'proofFormat' => 'jwt',
 		);
-		$args = array(
-			'headers' => array(
-				'Content-Type' => 'application/json',
-				'authorization' => 'Bearer ' . get_option( TRUST_AGENT_API_KEY_OPTION_KEY ),
-				'tenantid' => get_option( TRUST_AGENT_ID_OPTION_KEY ),
-			),
-			'body' => json_encode( $post_body ),
-		);
 
-		$res = wp_remote_post( get_option( TRUST_AGENT_BASE_URL_OPTION_KEY, TRUST_AGENT_BASE_URL_DEFAULT ) . '/v1/tenant/agent/createVerifiableCredential', $args );
-		if ( is_wp_error( $res ) ) {
-			throw new \Exception( 'error making sign VC request: ' . json_encode( $res ) );
-		} else if ( $res['response']['code'] < 200 || $res['response']['code'] >= 300 ) {
-			throw new \Exception( 'error response from sign VC request: ' . $res['response']['code'] . ': ' . $res['response']['message'] );
-		}
 
-		$response_body = json_decode( $res['body'] );
-		if ( $response_body && $response_body->proof && $response_body->proof->jwt ) {
-			return $response_body->proof->jwt;
-		} else {
-			throw new \Exception( 'invalid response body from sign VC request: ' . $res['body'] );
-		}
+		// @TODO/tobek Errors here fail silently, need to surface in post editor.
+		$response = Daf_Service::instance()->create_verifiable_credential( $body );
+
+		return $response;
 	}
 
 	/**
@@ -282,6 +267,7 @@ class Post_VC_Pub {
 		}
 
 		$last_pub_date = get_post_meta( $post->ID, LAST_VC_PUB_DATE_META_KEY, true );
+		$vc = get_vc_for_post_id( $post->ID );
 
 		if ( ! get_option( ASSIGNED_DID_OPTION_KEY ) ) {
 			_e( 'Cannot publish VC: DID not initialized' );
@@ -320,8 +306,14 @@ class Post_VC_Pub {
 			<p>A VC has not been published for the latest revision of this post. VC last published <?php echo esc_html( $time_string ); ?>.</p>
 		<?php } else { ?>
 			<p>No VC has been published for this post yet.</p>
-		<?php } ?>
+			<?php
+		}
 
+		if ( ! empty( $vc ) ) {
+			?>
+			<p>VC JSON:</p>
+			<pre style="overflow-x: scroll; white-space: pre-wrap;"><?php echo esc_html( $vc ); ?></pre>
+		<?php } ?>
 
 		<p><a href="<?php echo esc_url( menu_page_url( DID_SETTINGS_PAGE, false ) ); ?>" target="_blank">Edit settings</a></p>
 		<?php

--- a/consensys-publisher.php
+++ b/consensys-publisher.php
@@ -18,6 +18,7 @@ const SCHEMA_VERSION = '0.0.1';
 // Post meta.
 const POST_UUID_META_KEY = 'consensys_vc_publisher_post_uuid';
 const LAST_VC_PUB_DATE_META_KEY = 'consensys_vc_publisher_last_vc_pub_date';
+const POST_VC_META_KEY = 'consensys_vc_publisher_post_vc';
 
 // Site options.
 const DID_IS_ENABLED_OPTION_KEY = 'consensys_vc_publisher_did_is_enabled';
@@ -25,11 +26,7 @@ const DID_IS_ENABLED_DEFAULT = true;
 const DID_ERROR_OPTION_KEY = 'consensys_vc_publisher_did_error';
 const ASSIGNED_DID_OPTION_KEY = 'consensys_vc_publisher_assigned_did';
 const VC_LOG_OPTION_KEY = 'consensys_vc_publisher_vc_log';
-const TRUST_AGENT_BASE_URL_OPTION_KEY = 'consensys_vc_publisher_trust_agent_base_url';
-const TRUST_AGENT_BASE_URL_DEFAULT = 'https://alpha.consensysidentity.com';
-// const TRUST_AGENT_BASE_URL_DEFAULT = 'http://10.0.2.2:8000'; // 10.0.2.2 routes from VM guest to localhost on VM host.
-const TRUST_AGENT_ID_OPTION_KEY = 'consensys_vc_publisher_trust_agent_id';
-const TRUST_AGENT_API_KEY_OPTION_KEY = 'consensys_vc_publisher_trust_agent_api_key';
+const DAF_BASE_URL_OPTION_KEY = 'consensys_vc_publisher_daf_base_url';
 const PUB_VC_BY_DEFAULT_ON_NEW_OPTION_KEY = 'consensys_vc_publisher_pub_vc_by_default_on_new';
 const PUB_VC_BY_DEFAULT_ON_NEW_DEFAULT = true;
 const PUB_VC_BY_DEFAULT_ON_UPDATE_OPTION_KEY = 'consensys_vc_publisher_pub_vc_by_default_on_update';
@@ -51,4 +48,5 @@ require_once dirname( __FILE__ ) . '/traits/trait-singleton.php';
 
 require_once dirname( __FILE__ ) . '/admin.php';
 require_once dirname( __FILE__ ) . '/did-vc.php';
+require_once dirname( __FILE__ ) . '/classes/class-daf-service.php';
 require_once dirname( __FILE__ ) . '/classes/class-post-vc-pub.php';

--- a/did-settings.php
+++ b/did-settings.php
@@ -18,7 +18,7 @@ if ( current_user_can( 'manage_options' ) && isset( $_GET['clear-vc-log'] ) ) {
 	delete_option( ASSIGNED_DID_OPTION_KEY );
 	?>
 		<p>DID reset.</p>
-		<p>If organization ID and API key are set, DID initialization process will be run on next admin page load.</p>
+		<p>Note that if DAF Agent URL is set, DID initialization process will be run on next admin page load.</p>
 		<p><a href="<?php echo esc_url( menu_page_url( DID_SETTINGS_PAGE, false ) ); ?>">&laquo; Return to settings</a></p>
 	<?php
 	exit;
@@ -44,12 +44,12 @@ $did_doc_url = site_url( '/.well-known/did.json' );
 		<table class="form-table">
 			<tbody>
 				<tr>
-					<th scope="row">TrustAgent DID</th>
+					<th scope="row">Site DID</th>
 					<td>
 						<pre style="max-width: 600px; white-space: pre-wrap; margin: 0;"><?php echo esc_html( get_option( ASSIGNED_DID_OPTION_KEY, '[not set]' ) ); ?></pre>
 						<?php if ( get_option( ASSIGNED_DID_OPTION_KEY ) ) { ?>
 							<p><a href="<?php echo esc_url( menu_page_url( DID_SETTINGS_PAGE, false ) . '&reset-did' ); ?>"><br><button>Reset DID</button></a></p>
-							<p>(Note that if organization ID and API key are set, the DID initialization process will be run on next admin page load.)</p>
+							<p>(Note that if DAF Agent URL is set, the DID initialization process will be run on next admin page load.)</p>
 						<?php } ?>
 					</td>
 				</tr>


### PR DESCRIPTION
Instructions for running locally with DAF server:

```
git clone git@github.com:uport-project/daf.git
cd daf
git checkout beta
yarn install
yarn bootstrap
yarn build
yarn workspace daf-cli daf server
```

This will use ngrok to host a local DAF server. The output will show API base path e.g. https://f9cc4ac01d2d.ngrok.io/agent, and this is what you paste as DAF Agent URL into the ConsenSys VC Publisher Settings page in plugin, and then it should work: "Site DID" should show up on settings page, and when you check the "Publish/Update VC" checkbox on sidebar of edit post page and publish/update, and then refresh the page, you should see the VC JSON in the sidebar. Error messages, if any, are shown at the bottom of the plugin settings page.

`get_vc_for_post_id($post_id)` will return VC as JSON string.